### PR TITLE
Fixes to external triggering

### DIFF
--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -885,6 +885,9 @@ void loop() {
                 update();
             }
 
+            // Re-initialize PIO in case timing has changed.
+            init_pio();
+
             OK();
         }
     } else if (strncmp(readstring, "set ", 4) == 0) {

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -49,6 +49,7 @@
 #define P2 17
 #define P3 16
 #define TRIGGER 8
+#define INT_TRIGGER 7
 
 #define PIO_TRIG pio0
 #define PIO_TIME pio1
@@ -119,9 +120,13 @@ void init_pin(uint pin) {
 
 void init_pio() {
     uint offset = pio_add_program(PIO_TRIG, &trigger_program);
-    trigger_program_init(PIO_TRIG, 0, offset, TRIGGER, P3, PIN_UPDATE);
-    offset = pio_add_program(PIO_TIME, &timer_program);
-    timer_program_init(PIO_TIME, 0, offset, TRIGGER);
+	uint trigger = timing ? INT_TRIGGER : TRIGGER;
+    trigger_program_init(PIO_TRIG, 0, offset, trigger, P3, PIN_UPDATE);
+
+    if(timing) {
+        offset = pio_add_program(PIO_TIME, &timer_program);
+        timer_program_init(PIO_TIME, 0, offset, TRIGGER, INT_TRIGGER);
+    }
 }
 
 int get_status() {
@@ -194,10 +199,18 @@ void abort_run() {
         set_status(ABORTING);
 
         // take control of trigger pin from PIO
-        init_pin(TRIGGER);
-        gpio_put(TRIGGER, 1);
-        sleep_ms(1);
-        gpio_put(TRIGGER, 0);
+        if(timing) {
+            init_pin(INT_TRIGGER);
+            gpio_put(INT_TRIGGER, 1);
+            sleep_ms(1);
+            gpio_put(INT_TRIGGER, 0);
+        }
+        else {
+            init_pin(TRIGGER);
+            gpio_put(TRIGGER, 1);
+            sleep_ms(1);
+            gpio_put(TRIGGER, 0);
+        }
 
         // reinit PIO to give Trigger pin back
         init_pio();

--- a/dds-sweeper/trigger_timer.pio
+++ b/dds-sweeper/trigger_timer.pio
@@ -92,7 +92,7 @@ hwstart:
         pio_gpio_init(pio, trigger_pin);
         pio_gpio_init(pio, int_trigger_pin);
         pio_sm_set_pindirs_with_mask(pio, sm, 
-                                     (1u << trigger_pin) | (1u << int_trigger_pin),
+                                     (0u << trigger_pin) | (1u << int_trigger_pin),
                                      (1u << trigger_pin) | (1u << int_trigger_pin)
         );
         sm_config_set_sideset_pins(&c, int_trigger_pin);

--- a/dds-sweeper/trigger_timer.pio
+++ b/dds-sweeper/trigger_timer.pio
@@ -15,7 +15,8 @@ trigger:
     wait 1 pin 0
     out pins, 4         side 1 [3]
     out pins, 4         side 0
-    push                
+    push
+    wait 0 pin 0
  
 
 
@@ -83,17 +84,18 @@ hwstart:
     }
 
     static inline void timer_program_init(PIO pio, uint sm, uint offset,
-        uint trigger_pin
+                                          uint trigger_pin, uint int_trigger_pin
     ) {
         pio_sm_config c = timer_program_get_default_config(offset);
     
 
         pio_gpio_init(pio, trigger_pin);
+        pio_gpio_init(pio, int_trigger_pin);
         pio_sm_set_pindirs_with_mask(pio, sm, 
-            (1u << trigger_pin),
-            (1u << trigger_pin)
+                                     (1u << trigger_pin) | (1u << int_trigger_pin),
+                                     (1u << trigger_pin) | (1u << int_trigger_pin)
         );
-        sm_config_set_sideset_pins(&c, trigger_pin);
+        sm_config_set_sideset_pins(&c, int_trigger_pin);
         sm_config_set_in_pins(&c, trigger_pin);
 
         sm_config_set_out_shift(&c, true, false, 1);


### PR DESCRIPTION
At the moment, it seems that external triggering does not work well due to the timer PIO setting the trigger pin as an input. This PR attempts to resolve that issue with two changes:

1. The timer PIO has an always-input trigger pin and a separate "internal trigger" pin used to trigger the trigger PIO.
2. The trigger PIO's trigger is switched between the always-input trigger pin and the "internal trigger" pin for external and internal timing, respectively.

This pull request also makes the trigger PIO edge triggered, rather than level triggered. This is accomplished by waiting for the external/internal trigger to go low after messaging the CPU that the trigger has completed. This means that a trigger must have a 4 cycle minimum low.