### PR TITLE
More Set Commands and Binary Transfers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Guide to contributing to DDS Sweeper
+
+## Overview of structure
+
+The DDS Sweeper can be divided into four components:
+1. A serial interface to the host computer running on the first core.
+2. An SPI interface to the AD9959 running on the second core.
+4. A PIO program for internal triggering (referred to as "timing") the DDS Sweeper.
+3. A PIO program for sending triggers to the AD9959.
+
+## Serial interface
+
+The serial interface is mostly defined in the `void loop()` function.
+
+The `fast_serial` library is used to read strings of up to 256 characters into a buffer, which is then parsed.
+The first word (space separated) in the buffer is used to determine the command through `strncmp` in a large `if`-`else if`-`else` structure.
+Certain commands can not be run while the program is executing.
+The behavior of most commands is described in the [README](README.md).
+
+## Program storage
+
+The `set`, `seti`, and `setb` commands are used to load a program into RAM.
+Programs are stored in the `instructions` array in RAM.
+Programs consist of profile pin information, SPI commands and timing information.
+Both are stored in the same array, but timing information is offset to be after all the SPI commands.
+
+The `instructions` array (when all four channels are enabled by `setchannels`) thus contains
+
+```
+    [profile pin for address 0] [channel 0 instruction at address 0] [channel 1 instruction at address 0] ... [channel 3 instruction at address 0]
+    [profile pin for address 1] [channel 0 instruction at address 1] [channel 1 instruction at address 1] ... [channel 3 instruction at address 1]
+    ...
+    [profile pin for last address] [channel 0 instruction at last address] [channel 1 instruction at last address] ... [channel 3 instruction at last address]
+	0x00 [0x00 for stop or 0xFF for repeat]
+	...
+	[time for instruction at address 0]
+	[time for instruction at address 1]
+	...
+	[time for instruction at last address]
+```
+
+The profile pin byte is used in sweep modes to determine which profile pins to trigger (although SPI instructions will be sent for all channels, some of these could be empty, in which case nothing would happen to those channels). In single step mode, it is simply set to a non-zero value to indicate the the program does not stop or repeat yet.
+
+## Program execution
+
+The `void background()` function runs on the second core, sending SPI commands to the AD9959.
+
+A multicore fifo is used to instruct the second core to start (or to wait for an external trigger to start).
+
+It then counts the number of instructions (by scanning the `instructions` array for a `stop` instruction). If external timing is enabled, timing information is loaded from the `instructions` array to the timer PIO program using DMA.
+
+It then enters a loop of sending SPI commands and waiting for triggers (via the `void wait(uint channel)` function). Triggers can be provided by an external trigger or the timer PIO program.
+
+Triggers are also routed to the trigger PIO program, which takes in the profile pin byte and uses that to send triggers to the AD9959 profile pins (which starts sweeps that have already been programmed).
+
+## PIO programs
+
+### Timer program
+
+The timer PIO program reads delays in via the FIFO (which is refilled via DMA) and activates a trigger when delays are complete. It also waits for an external trigger if the delay is zero.
+
+### Trigger program
+
+The trigger PIO program sets the profile and update pins of the AD9959, which allows for more precise control over the DDS timing. It reads in a list of profile pins to update, then updates those and activates the AD9959 update pin when triggered.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Note: Commands must be terminated with `\n`.
 Responds with a string containing the firmware version.
 
 * `status`:  
-Returns the opperating status of the DDS-Sweeper. `0` status indicates manual mode. `1` status indicates buffered execution.
+Returns the opperating status of the DDS-Sweeper. `0` status indicates manual mode. `1` status indicates buffered execution. `2` status indicates aborting buffered execution.
 
 * `getfreqs`:  
 Responds with a multi-line string containing the current operating frequencies of various clocks (you will be most interested in `pll_sys` and `clk_sys`). Multiline string ends with `ok\n`.
@@ -130,12 +130,11 @@ Configures what mode the DDS-Sweeper is operating in
   - 3: phase sweep
   - 4: amplitude sweep with frequency/phase steps
   - 5: frequency sweep with amplitude/phase steps
-  - 6: phase sweep with amplitude/frequency steps0  
+  - 6: phase sweep with frequency/amplitude steps  
 
   The operating mode must be set before buffered execution instructions can be programmed into the DDS-Sweeper.  
   A `trigger-source` of `0` means the Sweeper is expecting external triggers. A `trigger-source` of `1` means the Sweeper will send its own triggers and `set` commands will require an aditional `time` argument.
-  The Sweeper must be in manual mode in order for the `setfreq`, `setphase`, and `setamp` commands to work.
-  
+
 ### Manual output commands
 
 
@@ -156,9 +155,9 @@ Manually set the amplitude scale factor of a specified channel. Channels are 0-3
 * `set`:  
 Sets the value of instruction number `addr` for channel `channel` (zero indexed). `addr` starts at 0. It looks different depending on what mode the sweeper is in. If `Debug` is set to `on` it will respond with the actual values set for that instruction.
   - Single Stepping (mode 0): `set <channel:int> <addr:int> <frequency:float> <amplitude:float> <phase:float> (<time:int>)`
-  - Sweep Mode (modes 1-3): `set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> <ramp-rate:int> (<time:int>)`
+  - Sweep Mode (modes 1-3): `set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> (<time:int>)`
 
-    `start_point` is the value the sweep should start from, and `end_point` is where it will stop. `delta` is the amount that the output should change by every cycle of the sweep clock. In the AD9959, the sweep clock runs at one quarter the system clock. `ramp-rate` is an additional divider that can applied to slow down the sweep clock further, must be in the range 1-255. The types of values expected for `start_point`, `end_point`, and `delta` different depending on the type of sweep  
+    `start_point` is the value the sweep should start from, and `end_point` is where it will stop. `delta` is the amount that the output should change by every cycle of the sweep clock. In the AD9959, the sweep clock runs at one quarter the system clock. The types of values expected for `start_point`, `end_point`, and `delta` different depending on the type of sweep  
       - Amplitude Sweeps (mode 1)  
         `start_point` and `end_point` should be decimals between 0 and 1 that represent the desired proprtion of the maximum output amplitude. `delta` is the desired change in that proprtion. For all three of those values there is a resolution of $\frac{1}{1024} \approx 0.09766\$
       - Frequency Sweeps (mode 2)  
@@ -166,7 +165,7 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
       - Phase Sweeps (mode 3)
         `start_point`, `end_point`, and `delta` are in degrees. They can have decimal values, but they will be rounded to the nearest multiple of the phase resolution (always $= 360^\circ / 2^{14} \approx 0.02197^\circ$). 
 
-  - Sweep and Single Stepping Mode (modes 4-6): `set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> <ramp-rate:int> <secondary1:double> <secondary2:double> (<time:int>)`
+  - Sweep and Single Stepping Mode (modes 4-6): `set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> <secondary1:double> <secondary2:double> (<time:int>)`
 
     These modes perform a linear sweep on one of the parameters, while simulaneously single stepping on the other two parameters.
       - Amplitude Sweeps (mode 4)  
@@ -174,7 +173,7 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
       - Frequency Sweeps (mode 5)  
         `secondary1` is the amplitude scale factor, and `secondary2` is the phase offset.
       - Phase Sweeps (mode 6)  
-        `secondary1` is the amplitude scale factor, and `secondary2` is the frequency.
+        `secondary1` is the frequency, and `secondary2` is the amplitude scale factor.
 
 
 * `seti`:  
@@ -198,7 +197,7 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
       - Frequency Sweeps (mode 5)  
         `secondary1` is the amplitude scale factor, and `secondary2` is the phase offset.
       - Phase Sweeps (mode 6)  
-        `secondary1` is the amplitude scale factor, and `secondary2` is the frequency.
+        `secondary1` is the frequency, and `secondary2` is the amplitude scale factor.
 
 * `setb <start address:int> <instruction count:int>`:  
 Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent:  

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Finally, the mode and timing should be setup with the `mode` command. The DDS Sw
 
 ### Program loading
 
-Once setup is complete, instructions (steps or sweeps, depending on the mode) can be loaded using the `set`, `seti`, or `setb` commands. In addition to output instructions, there are special stop and repeat instructions (which can only be loaded using `seti` and `setb`). With instructions are loaded, the address (order in which they are executed) is specified, so the order of loading need not match the order of execution. The stop instruction ends program execution, while the repeat instruction restarts program execution from the beginning. Instructions are loaded into an uninitialized array, so skipping instruction addresses or failing to specify stop/repeat at the end of the program may result in undefined behavior.
+Once setup is complete, instructions (steps or sweeps, depending on the mode) and timings can be loaded using the `set`, `seti`, or `setb` commands. In addition to output instructions, there are special stop and repeat instructions (which can only be loaded using `seti` and `setb`). With instructions are loaded, the address (order in which they are executed) is specified, so the order of loading need not match the order of execution. Timing is set per address, so it is common to all channels. The stop instruction ends program execution, while the repeat instruction restarts program execution from the beginning. Instructions are loaded into an uninitialized array, so skipping instruction addresses or failing to specify stop/repeat at the end of the program may result in undefined behavior.
 
 ### Execution
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,48 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
         `secondary1` is the amplitude scale factor, and `secondary2` is the phase offset.
       - Phase Sweeps (mode 6)  
         `secondary1` is the amplitude scale factor, and `secondary2` is the frequency.
-        
 
-  
+
+* `seti`:  
+Sets the value of instruction number `addr` for channel `channel` (zero indexed). `addr` starts at 0. It looks different depending on what mode the sweeper is in. If `Debug` is set to `on` it will respond with the actual values set for that instruction. `seti` uses integer values (AD9959 units) rather than floating point values. Otherwise, it is the same as `set`.
+  - Single Stepping (mode 0): `seti <channel:int> <addr:int> <frequency:int> <amplitude:int> <phase:int> (<time:int>)`
+  - Sweep Mode (modes 1-3): `seti <channel:int> <addr:int> <start_point:int> <end_point:int> <delta:int> <ramp-rate:int> (<time:int>)`
+
+    `start_point` is the value the sweep should start from, and `end_point` is where it will stop. `delta` is the amount that the output should change by every cycle of the sweep clock. In the AD9959, the sweep clock runs at one quarter the system clock. `ramp-rate` is an additional divider that can applied to slow down the sweep clock further, must be in the range 1-255. The types of values expected for `start_point`, `end_point`, and `delta` different depending on the type of sweep  
+      - Amplitude Sweeps (mode 1)  
+        `start_point` and `end_point` should be integers between 0 and 1023 (inclusive).
+      - Frequency Sweeps (mode 2)  
+        `start_point`, `end_point`, and `delta` are integers between 0 and $2^{32} - 1$ in units of system clock rate (typically $500$ MHz) over $2^{32}$.
+      - Phase Sweeps (mode 3)
+        `start_point`, `end_point`, and `delta` are between 0 and 65535 (inclusive).
+
+  - Sweep and Single Stepping Mode (modes 4-6): `set <channel:int> <addr:int> <start_point:int> <end_point:int> <delta:int> <ramp-rate:int> <secondary1:int> <secondary2:int> (<time:int>)`
+
+    These modes perform a linear sweep on one of the parameters, while simulaneously single stepping on the other two parameters.
+      - Amplitude Sweeps (mode 4)  
+        `secondary1` is the frequency, and `secondary2` is the phase offset.
+      - Frequency Sweeps (mode 5)  
+        `secondary1` is the amplitude scale factor, and `secondary2` is the phase offset.
+      - Phase Sweeps (mode 6)  
+        `secondary1` is the amplitude scale factor, and `secondary2` is the frequency.
+
+
+* `setb <start address:int> <instruction count:int>`:  
+Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent:  
+   - Single Stepping (mode 0): `<frequency:int 32> <amplitude:int 16> <phase:int 16>`. Total of 8 bytes per channel per instruction.  
+   - Single Stepping (mode 0) with timing: `<frequency:int 32> <amplitude:int 16> <phase:int 16> <time: int 32>`. Total of 12 bytes per channel per instruction.  
+   - Amplitude Sweeps (mode 1): `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8>`. Total of 7 bytes per channel per instruction.  
+   - Amplitude Sweeps (mode 1) with timing: `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <time:int 32>`. Total of 11 bytes per channel per instruction.  
+   - Frequency Sweeps (mode 2): `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8>`. Total of 13 bytes per channel per instruction.  
+   - Frequency Sweeps (mode 2) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <time:int 32>`. Total of 17 bytes per channel per instruction.  
+   - Phase Sweeps (mode 1): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8>`. Total of 7 bytes per channel per instruction.  
+   - Phase Sweeps (mode 1) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <time:int 32>`. Total of 11 bytes per channel per instruction.  
+   - Amplitude Sweep and Single Stepping (mode 4): `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <phase:int 16>`. Total of 13 bytes per channel per instruction.  
+   - Amplitude Sweep and Single Stepping (mode 4) with timing: `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <phase:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.  
+   - Frequency Sweep and Single Stepping (mode 5): `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <amplitude:int 16> <phase:int 16>`. Total of 17 bytes per channel per instruction.  
+   - Frequency Sweep and Single Stepping (mode 5) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <amplitude:int 16> <phase:int 16> <time:int 32>`. Total of 21 bytes per channel per instruction.  
+   - Phase Sweep and Single Stepping (mode 6): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16>`. Total of 13 bytes per channel per instruction.  
+   - Phase Sweep and Single Stepping (mode 6) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.
 
 
 * `numtriggers`:  

--- a/README.md
+++ b/README.md
@@ -44,15 +44,34 @@ The Pico should mount as a mass storage device (if it doesn't, try again or cons
 Drag and drop the `.uf2` file into the mounted mass storage device.
 The mass storage device should unmount after the copy completes. Your Pico is now running the DDS Sweeper firmware!
 
-## Notes
+## Usage
+
+### Setup
+
+When the DDS Sweeper is started, configuration is required before it can be used. It is often good to begin with a `reset` command, which resets the AD9959.
+
+First, the clock should be setup with the `setclock` command, followed by the `setmult` command.
+
+Second, the number of channels should be configured with the `setchannels` command.
+
+Finally, the mode and timing should be setup with the `mode` command. The DDS Sweeper uses either discrete amplitude, frequency, and phase steps or sweeps of one parameter (possibly with steps of the other parameter) as its primitive instructions. The DDS Sweeper can then use internal timing (in which case it generates triggers internally after each step or sweep) or external timing (in which case it waits for external triggers).
+
+### Program loading
+
+Once setup is complete, instructions (steps or sweeps, depending on the mode) can be loaded using the `set`, `seti`, or `setb` commands. In addition to output instructions, there are special stop and repeat instructions (which can only be loaded using `seti` and `setb`). With instructions are loaded, the address (order in which they are executed) is specified, so the order of loading need not match the order of execution. The stop instruction ends program execution, while the repeat instruction restarts program execution from the beginning. Instructions are loaded into an uninitialized array, so skipping instruction addresses or failing to specify stop/repeat at the end of the program may result in undefined behavior.
+
+### Execution
+
+Finally, the program can be executed using the `start` or `hwstart` commands. If termination of the program is required before it reaches a `stop` command, the `abort` command can be used.
+
+## DDS Units
 - Output Amplitude is dependent on frequency (some people on Analog Devices forum mentioned amplitude and frequency are related by a sinc function)
 
-- The frequency resolution of the AD9959 is $= \frac{f_{sys clk}}{2^{32}}$. At the default system clock of 500 MHz, the frequency resolution is $\approx 0.1164$ Hz. Any frequency input to the dds-sweeper will be rounded to an integer multiple of the frequency resolution.
+- The frequency resolution of the AD9959 is $= \frac{f_{sys clk}}{2^{32}}$. At the default system clock of 500 MHz, the frequency resolution is $\approx 0.1164$ Hz. Frequency input to the DDS Sweeper using the `set` command will be rounded to an integer multiple of the frequency resolution. Frequency input to the DDS Sweeper using the `seti` or `setb` commands will be in units of the frequency resolution.
 
-- The phase resolution of the AD9959 is $= \frac{360^\circ}{2^{14}} \approx 0.02197^\circ$. Phase offsets will be rounded to a multiple of this resolution
+- The phase resolution of the AD9959 is $= \frac{360^\circ}{2^{14}} \approx 0.02197^\circ$. Phase offsets given using the `set` command will be rounded to a multiple of this resolution. Phase offets given using the `seti` or `setb` commands will be in units of this resolution.
 
-- The amplitude resolution of the AD9959 is $= \frac{1}{2^{10}} \approx 0.09767\%$. Amplitude scale factors will be rounded to a multiple of this resolution
-
+- The amplitude resolution of the AD9959 is $= \frac{1}{2^{10}} \approx 0.09767\%$. Amplitude scale factors given using the `set` command will be rounded to a multiple of this resolution. Amplitude scale factors given using the `seti` or `setb` commands will be in units of this resolution.
 
 ## Sweeps
 - Setting up a sweep:  
@@ -61,83 +80,63 @@ Sweeps are defined by two parameters, sweep delta and ramp rate.
 - Sweep Delta defines the change in output amplitude/frequency/phase on each sweep step
 - Ramp rate defines how often a sweep step is taken. It is based off of the AD9959's sync clock signal which will be one quarter of the AD9959's system clock. The ramp rate parameter specifies the number of sync clock cycles per sweep step. A ramp rate of 1 will cause the sweep delta to be applied every 1 sync clock cycle. For upward sweeps, the ramp rate parameter can have a value of 1-255. For downward sweeps the ramp rate can only be 1.  
 
-
-The time between sweep steps can be calculated with:
-$$ t = \frac{\textrm{Ramp Rate}}{\textrm{Sync Clock}} $$
-Using the Pico's 125 Mhz with a 4 times PLL Multiplier gives the AD9959 a system clock of 500 MHz and therefore a sync clock of 125 MHz.
-For upward sweeps the time between sweeps can range from $\frac{1}{125 MHz} = 8 ns$ to $\frac{255}{125 MHz} = 2.04 \mu s$.
-Downward sweeps will apply the sweep delta every $\frac{1}{125 MHz} = 8 ns$.  
-Given the frequency resolution of $\frac{f_{sys clk}}{2^{32}}$, the smallest sweep delta is $= \frac{1}{2^{32}} = 0.1164$ Hz. With the maximum ramp rates, the DDS-sweeper has a minimum sweeping rate of $\approx 47871$ Hz/sec when sweeping upwards or $\approx 12207031.25$ Hz/sec when sweeping downward.
-
-
-### Downward Sweeps:
-Downward sweeps are not well supported by the AD9959, but they can still be done.
-The best method I have found for doing a downward sweep is to send the instructions via serial first, with the sweep autoclear bit set to active and the rising sweep tuning word set to the maximum.
-Then issue the IO_UPDATE signal while keeping the profile pin for that channel high.
-I belive this clears the sweep accumulator then quickly refills it with a max rate sweep before beginning the downward sweep. 
-Other combinations of autoclear bit active or not and timing of the profile pins seem to cause even more issues with downward sweeps.
-The biggest downside of this method is that you cannot slow down the downward sweep ramp rate as much as the upward sweep ramp rate.
-
-
-- Autoclear Accumulator Active, drop the pin after the update:  
-  Seems to work, you just cannot slow down downward sweeps. 
-  ![Autoclear Accumulator Active, drop the pin after the update Closeup](img/profile-pin-drop-after.png)  
-  ![Autoclear Accumulator Active, drop the pin after the update Multiple Sweeps](img/noise-on-transition.png)   
-
-- Autoclear Accumulator Active, drop the pin before the update:  
-  Downward sweeps just dont work at all.  
-  ![Autoclear Accumulator Active, drop the pin before the update: Closeup](img/profile-pin-drop.png)  
-  ![Autoclear Accumulator Active, drop the pin before the update: Multiple Sweeps](img/no-down-sweeps.png)  
-
-- no autoclear, drop pin before update:  
-  You cannot do consecutive down sweeps - every down sweep must be preceeded by an up sweep  
-  ![no autoclear, drop pin before update: Closeup](img/no-auto-drop-before.png)  
-  ![no autoclear, drop pin before update: Multiple Sweeps](img/consecutive-downs.png)  
-
-- no autoclear, drop pin after update:    
-  A down sweep after an up sweep cannot cover a greater distance than the upward sweep  
-  ![no autoclear, drop pin after update: Closeup](img/no-auto-drop-after.png)  
-  ![no autoclear, drop pin after update: Multiple Sweeps](img/incomplete-sweep-after.png)  
-
-- You can also generate a downward sweep by operating the AS9959 above the nyquist frequency.
-This method does work but causes discontinuity when switching which band the AD9959 is working in.  
-![Scope trace of noise on DDS band transitions](img/aan.png)
-
-
+For more details on sweeps, see [sweep details](SWEEP_DETAILS.md).
 
 ## Serial API
 Note: Commands must be terminated with `\n`.
 
+### Status commands
+
 * `version`:  
 Responds with a string containing the firmware version.
-
-
-* `abort`:  
-Stops buffered execution immediately.
-
 
 * `status`:  
 Returns the opperating status of the DDS-Sweeper. `0` status indicates manual mode. `1` status indicates buffered execution.
 
-
 * `getfreqs`:  
 Responds with a multi-line string containing the current operating frequencies of various clocks (you will be most interested in `pll_sys` and `clk_sys`). Multiline string ends with `ok\n`.
 
+### State commands
 
-* `debug <state:str>`:  
-Turns on extra debug messages printed over serial. `state` should be `on` or `off` (no string quotes required).
+* `start`:  
+Starts buffered execution immediately.
 
+* `hwstart`:  
+Starts buffered execution once an external trigger is received.
+
+* `abort`:  
+Stops buffered execution immediately.
+
+### Setup commands
+
+* `setclock <mode:int> <freq:int>`:  
+Reconfigures the source/reference clock.
+  - Mode `0`: Use pico system clock as reference to the AD9959
+  - Mode `1`: Sets the AD9959 to recieve a reference clock not from the pico
+
+* `setmult <pll_mult:int>`:    
+Sets the AD9959's pll multiplier on the Reference Clock input. The default value is 4, giving the AD9959 a system clock of 500 MHz with the pico's 125 MHz reference. Valid values are 1 or 4-20.  
+If changing the reference clock and PLL multiplier, you should set the reference clock frequency first.  
+The AD9959's PLL has an output range of 100-160 MHz or 255-500 MHz with VCO gain enabled. The pico will automatically enable the VCO gain bit if the requested frequency is in the upper range. If trying to use the PLL multiplier to generate a frequency between 160 and 255 MHz, there is no guarantee of operation.
+
+* `setchannels <num:int>`:  
+Sets how many channels being used by the table mode. Uses the lowest channels first, starting with channel 0. If number of channels is set to `1`, buffered execution instructions will be written to all 4 channels simultaneously.
 
 * `mode <sweep-type:int> <trigger-source:int>`:  
 Configures what mode the DDS-Sweeper is operating in
   - 0: single stepping / manual mode
   - 1: amplitude sweep
   - 2: frequency sweep
-  - 3: phase sweep  
+  - 3: phase sweep
+  - 4: amplitude sweep with frequency/phase steps
+  - 5: frequency sweep with amplitude/phase steps
+  - 6: phase sweep with amplitude/frequency steps0  
 
   The operating mode must be set before buffered execution instructions can be programmed into the DDS-Sweeper.  
   A `trigger-source` of `0` means the Sweeper is expecting external triggers. A `trigger-source` of `1` means the Sweeper will send its own triggers and `set` commands will require an aditional `time` argument.
   The Sweeper must be in manual mode in order for the `setfreq`, `setphase`, and `setamp` commands to work.
+  
+### Manual output commands
 
 
 * `setfreq <channel:int> <frequency:float>`:  
@@ -151,6 +150,8 @@ Manually set the phase offset of a specified channel. Channels are 0-3 and offse
 * `setamp <channel:int> <amplituce_scale_factor:float>`:  
 Manually set the amplitude scale factor of a specified channel. Channels are 0-3 and amplitude scale factors are a precentage of the maximum output voltage. If `debug` is set to on, it will respond with the actual frequency set. The Sweeper must be in manual mode.
 
+
+### Data loading commands
 
 * `set`:  
 Sets the value of instruction number `addr` for channel `channel` (zero indexed). `addr` starts at 0. It looks different depending on what mode the sweeper is in. If `Debug` is set to `on` it will respond with the actual values set for that instruction.
@@ -199,7 +200,6 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
       - Phase Sweeps (mode 6)  
         `secondary1` is the amplitude scale factor, and `secondary2` is the frequency.
 
-
 * `setb <start address:int> <instruction count:int>`:  
 Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent:  
    - Single Stepping (mode 0): `<frequency:int 32> <amplitude:int 16> <phase:int 16>`. Total of 8 bytes per channel per instruction.  
@@ -217,32 +217,24 @@ Bulk setting of instructions in binary. `start address` is the address of the fi
    - Phase Sweep and Single Stepping (mode 6): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16>`. Total of 13 bytes per channel per instruction.  
    - Phase Sweep and Single Stepping (mode 6) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.
 
-
-* `numtriggers`:  
-Responds with the nmumber of triggers processed since the last call of `start`
-
-* `setclock <mode:int> <freq:int>`:  
-Reconfigures the source/reference clock.
-  - Mode `0`: Use pico system clock as reference to the AD9959
-  - Mode `1`: Sets the AD9959 to recieve a reference clock not from the pico
-
-
-* `setmult <pll_mult:int>`:    
-Sets the AD9959's pll multiplier on the Reference Clock input. The default value is 4, giving the AD9959 a system clock of 500 MHz with the pico's 125 MHz reference. Valid values are 1 or 4-20.  
-If changing the reference clock and PLL multiplier, you should set the reference clock frequency first.  
-The AD9959's PLL has an output range of 100-160 MHz or 255-500 MHz with VCO gain enabled. The pico will automatically enable the VCO gain bit if the requested frequency is in the upper range. If trying to use the PLL multiplier to generate a frequency between 160 and 255 MHz, there is no guarantee of operation.
-
-* `setchannels <num:int>`:  
-Sets how many channels being used by the table mode. Uses the lowest channels first, starting with channel 0. If number of channels is set to `1`, buffered execution instructions will be written to all 4 channels simultaneously.
-
+### Flash commands
 
 * `save`:  
 Saves the buffered execution table to nonvolatile memory so that it can be recovered later (after a power cycle). 
 
-
 * `load`:  
 Retrieves the buffered execution table stored in nonvolatile memory and restores it to system memory so that it can be run. A saved table must be loaded before it can be run.
 
+### Debugging commands
+
+* `debug <state:str>`:  
+Turns on extra debug messages printed over serial. `state` should be `on` or `off` (no string quotes required).
+
+* `numtriggers`:  
+Responds with the nmumber of triggers processed since the last call of `start`
+
+* `program`:  
+Reboots the Pi Pico into firmware flashing mode. Serial will immediately disconnect and a mass storage device should appear.
 
 ## Compiling the firmware
 

--- a/SWEEP_DETAILS.md
+++ b/SWEEP_DETAILS.md
@@ -1,0 +1,48 @@
+## Sweeps
+- Setting up a sweep:  
+![Sweep Setup Figure](img/sweep-setup.png)  
+Sweeps are defined by two parameters, sweep delta and ramp rate. 
+- Sweep Delta defines the change in output amplitude/frequency/phase on each sweep step
+- Ramp rate defines how often a sweep step is taken. It is based off of the AD9959's sync clock signal which will be one quarter of the AD9959's system clock. The ramp rate parameter specifies the number of sync clock cycles per sweep step. A ramp rate of 1 will cause the sweep delta to be applied every 1 sync clock cycle. For upward sweeps, the ramp rate parameter can have a value of 1-255. For downward sweeps the ramp rate can only be 1.  
+
+
+The time between sweep steps can be calculated with:
+$ t = \frac{\textrm{Ramp Rate}}{\textrm{Sync Clock}} $
+Using the Pico's 125 Mhz with a 4 times PLL Multiplier gives the AD9959 a system clock of 500 MHz and therefore a sync clock of 125 MHz.
+For upward sweeps the time between sweeps can range from $\frac{1}{125 MHz} = 8 ns$ to $\frac{255}{125 MHz} = 2.04 \mu s$.
+Downward sweeps will apply the sweep delta every $\frac{1}{125 MHz} = 8 ns$.  
+Given the frequency resolution of $\frac{f_{sys clk}}{2^{32}}$, the smallest sweep delta is $= \frac{1}{2^{32}} = 0.1164$ Hz. With the maximum ramp rates, the DDS-sweeper has a minimum sweeping rate of $\approx 47871$ Hz/sec when sweeping upwards or $\approx 12207031.25$ Hz/sec when sweeping downward.
+
+
+### Downward Sweeps:
+Downward sweeps are not well supported by the AD9959, but they can still be done.
+The best method I have found for doing a downward sweep is to send the instructions via serial first, with the sweep autoclear bit set to active and the rising sweep tuning word set to the maximum.
+Then issue the IO_UPDATE signal while keeping the profile pin for that channel high.
+I belive this clears the sweep accumulator then quickly refills it with a max rate sweep before beginning the downward sweep. 
+Other combinations of autoclear bit active or not and timing of the profile pins seem to cause even more issues with downward sweeps.
+The biggest downside of this method is that you cannot slow down the downward sweep ramp rate as much as the upward sweep ramp rate.
+
+
+- Autoclear Accumulator Active, drop the pin after the update:  
+  Seems to work, you just cannot slow down downward sweeps. 
+  ![Autoclear Accumulator Active, drop the pin after the update Closeup](img/profile-pin-drop-after.png)  
+  ![Autoclear Accumulator Active, drop the pin after the update Multiple Sweeps](img/noise-on-transition.png)   
+
+- Autoclear Accumulator Active, drop the pin before the update:  
+  Downward sweeps just dont work at all.  
+  ![Autoclear Accumulator Active, drop the pin before the update: Closeup](img/profile-pin-drop.png)  
+  ![Autoclear Accumulator Active, drop the pin before the update: Multiple Sweeps](img/no-down-sweeps.png)  
+
+- no autoclear, drop pin before update:  
+  You cannot do consecutive down sweeps - every down sweep must be preceeded by an up sweep  
+  ![no autoclear, drop pin before update: Closeup](img/no-auto-drop-before.png)  
+  ![no autoclear, drop pin before update: Multiple Sweeps](img/consecutive-downs.png)  
+
+- no autoclear, drop pin after update:    
+  A down sweep after an up sweep cannot cover a greater distance than the upward sweep  
+  ![no autoclear, drop pin after update: Closeup](img/no-auto-drop-after.png)  
+  ![no autoclear, drop pin after update: Multiple Sweeps](img/incomplete-sweep-after.png)  
+
+- You can also generate a downward sweep by operating the AS9959 above the nyquist frequency.
+This method does work but causes discontinuity when switching which band the AD9959 is working in.  
+![Scope trace of noise on DDS band transitions](img/aan.png)

--- a/dds-sweeper/ad9959.c
+++ b/dds-sweeper/ad9959.c
@@ -9,7 +9,7 @@ double get_asf(double amp, uint16_t* asf) {
 
     // validation
     if (*asf > 1023) *asf = 1023;
-    if (*asf < 1) *asf = 1;
+    if (*asf < 0) *asf = 0;
 
     return *asf / 1023.0;
 }

--- a/dds-sweeper/ad9959.c
+++ b/dds-sweeper/ad9959.c
@@ -4,44 +4,51 @@
 // =============================================================================
 // calculate tuning words
 // =============================================================================
-double get_asf(double amp, uint8_t* buf) {
-    uint32_t asf = round(amp * 1024);
+double get_asf(double amp, uint16_t* asf) {
+    *asf = round(amp * 1024);
 
     // validation
-    if (asf > 1023) asf = 1023;
-    if (asf < 1) asf = 1;
+    if (*asf > 1023) *asf = 1023;
+    if (*asf < 1) *asf = 1;
 
-    buf[0] = 0x00;
-    buf[1] = ((0x300 & asf) >> 8) | 0x10;
-    buf[2] = 0xff & asf;
-
-    return asf / 1023.0;
+    return *asf / 1023.0;
 }
-double get_ftw(ad9959_config* c, double freq, uint8_t* buf) {
+
+double get_ftw(ad9959_config* c, double freq, uint32_t* ftw) {
     double sys_clk = c->ref_clk * c->pll_mult;
-    uint32_t ftw = round(freq * 4294967296.l / sys_clk);
+    *ftw = round(freq * 4294967296.l / sys_clk);
 
     // maybe add some validation here
 
-    // flip order of bits (little endian -> big endian)
-    uint8_t* bytes = (uint8_t*)&ftw;
-    for (int i = 0; i < 4; i++) {
-        buf[i] = bytes[3 - i];
-    }
-
     // return the frequency that was able to be set
-    return ftw * sys_clk / 4294967296.l;
+    return *ftw * sys_clk / 4294967296.l;
 }
-double get_pow(double phase, uint8_t* buf) {
-    uint32_t pow = round(phase / 360.0 * 16384.0);
+
+double get_pow(double phase, uint16_t* pow) {
+    *pow = round(phase / 360.0 * 16384.0);
 
     // make sure pow is within range?
-    pow = pow % 16383;
+    *pow = *pow % 16383;
 
-    buf[0] = (0xff00 & pow) >> 8;
-    buf[1] = 0xff & pow;
+    return *pow / 16383.0 * 360.0;
+}
 
-    return pow / 16383.0 * 360.0;
+void load_acr(uint16_t asf, uint8_t* buf) {
+    buf[0] = 0x00;
+    buf[1] = ((0x0300 & asf) >> 8) | 0x10;
+    buf[2] = 0xff & asf;
+}
+
+void load_ftw(uint32_t ftw, uint8_t* buf) {
+    buf[0] = (ftw & 0xFF000000) >> 24;
+    buf[1] = (ftw & 0x00FF0000) >> 16;
+    buf[2] = (ftw & 0x0000FF00) >> 8;
+    buf[3] = (ftw & 0x000000FF);
+}
+
+void load_pow(uint16_t pow, uint8_t* buf) {
+    buf[0] = (pow & 0xFF00) >> 8;
+    buf[1] = pow & 0x00FF;
 }
 
 // =============================================================================

--- a/dds-sweeper/ad9959.h
+++ b/dds-sweeper/ad9959.h
@@ -32,6 +32,56 @@
 
 #define SPI spi0
 
+// AD9959 registers
+#define AD9959_REG_CSR 0x00
+#define AD9959_REG_FR1 0x01
+#define AD9959_REG_FR2 0x02
+#define AD9959_REG_CFR 0x03
+#define AD9959_REG_FTW 0x04
+#define AD9959_REG_POW 0x05
+#define AD9959_REG_ACR 0x06
+#define AD9959_REG_LSRR 0x07
+#define AD9959_REG_RDW 0x08
+#define AD9959_REG_FDW 0x09
+#define AD9959_REG_CW 0x0A
+
+// Instruction memory maps
+// Defines offset in instruction array where register address is stored
+// Register value starts at offset of address + 1
+#define INS_PROFILE 0
+#define INS_CSR 1
+// For Single Step
+#define INS_SS_FTW 3
+#define INS_SS_POW 8
+#define INS_SS_ACR 11
+// For AMP/AMP2 sweep
+#define INS_AMP_ACR 3
+#define INS_AMP_LSRR 7
+#define INS_AMP_RDW 10
+#define INS_AMP_FDW 15
+#define INS_AMP_CW 20
+#define INS_AMP_CFR 25
+#define INS_AMP_FTW 29
+#define INS_AMP_POW 34
+// For FREQ/FREQ2 sweep
+#define INS_FREQ_FTW 3
+#define INS_FREQ_LSRR 8
+#define INS_FREQ_RDW 11
+#define INS_FREQ_FDW 16
+#define INS_FREQ_CW 21
+#define INS_FREQ_CFR 26
+#define INS_FREQ_ACR 30
+#define INS_FREQ_POW 34
+// For PHASE/PHASE2 sweep
+#define INS_PHASE_POW 3
+#define INS_PHASE_LSRR 6
+#define INS_PHASE_RDW 9
+#define INS_PHASE_FDW 14
+#define INS_PHASE_CW 19
+#define INS_PHASE_CFR 24
+#define INS_PHASE_FTW 28
+#define INS_PHASE_ACR 33
+
 typedef struct ad9959_config {
     double ref_clk;
     uint32_t pll_mult;

--- a/dds-sweeper/ad9959.h
+++ b/dds-sweeper/ad9959.h
@@ -47,40 +47,39 @@
 
 // Instruction memory maps
 // Defines offset in instruction array where register address is stored
-// Register value starts at offset of address + 1
-#define INS_PROFILE 0
-#define INS_CSR 1
+// Register value starts at offset of address
+#define INS_CSR 0
 // For Single Step
-#define INS_SS_FTW 3
-#define INS_SS_POW 8
-#define INS_SS_ACR 11
+#define INS_SS_FTW 2
+#define INS_SS_POW 7
+#define INS_SS_ACR 10
 // For AMP/AMP2 sweep
-#define INS_AMP_ACR 3
-#define INS_AMP_LSRR 7
-#define INS_AMP_RDW 10
-#define INS_AMP_FDW 15
-#define INS_AMP_CW 20
-#define INS_AMP_CFR 25
-#define INS_AMP_FTW 29
-#define INS_AMP_POW 34
+#define INS_AMP_ACR 2
+#define INS_AMP_LSRR 6
+#define INS_AMP_RDW 9
+#define INS_AMP_FDW 14
+#define INS_AMP_CW 19
+#define INS_AMP_CFR 24
+#define INS_AMP_FTW 28
+#define INS_AMP_POW 33
 // For FREQ/FREQ2 sweep
-#define INS_FREQ_FTW 3
-#define INS_FREQ_LSRR 8
-#define INS_FREQ_RDW 11
-#define INS_FREQ_FDW 16
-#define INS_FREQ_CW 21
-#define INS_FREQ_CFR 26
-#define INS_FREQ_ACR 30
-#define INS_FREQ_POW 34
+#define INS_FREQ_FTW 2
+#define INS_FREQ_LSRR 7
+#define INS_FREQ_RDW 10
+#define INS_FREQ_FDW 15
+#define INS_FREQ_CW 20
+#define INS_FREQ_CFR 25
+#define INS_FREQ_ACR 29
+#define INS_FREQ_POW 33
 // For PHASE/PHASE2 sweep
-#define INS_PHASE_POW 3
-#define INS_PHASE_LSRR 6
-#define INS_PHASE_RDW 9
-#define INS_PHASE_FDW 14
-#define INS_PHASE_CW 19
-#define INS_PHASE_CFR 24
-#define INS_PHASE_FTW 28
-#define INS_PHASE_ACR 33
+#define INS_PHASE_POW 2
+#define INS_PHASE_LSRR 5
+#define INS_PHASE_RDW 8
+#define INS_PHASE_FDW 13
+#define INS_PHASE_CW 18
+#define INS_PHASE_CFR 23
+#define INS_PHASE_FTW 27
+#define INS_PHASE_ACR 32
 
 typedef struct ad9959_config {
     double ref_clk;
@@ -90,9 +89,13 @@ typedef struct ad9959_config {
 } ad9959_config;
 
 // get tuning words
-double get_asf(double amp, uint8_t* buf);
-double get_ftw(ad9959_config* c, double freq, uint8_t* buf);
-double get_pow(double phase, uint8_t* buf);
+double get_asf(double amp, uint16_t* asf);
+double get_ftw(ad9959_config* c, double freq, uint32_t* ftw);
+double get_pow(double phase, uint16_t* pow);
+
+void load_acr(uint16_t asf, uint8_t* buf);
+void load_ftw(uint32_t ftw, uint8_t* buf);
+void load_pow(uint16_t pow, uint8_t* buf);
 
 // send tuning words
 void send_channel(uint8_t reg, uint8_t channel, uint8_t* buf, size_t len);

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -93,7 +93,7 @@ uint8_t instructions[MAX_SIZE];
 
 // bytes to encode an instruction in terms of sweep type
 // order is single step, amp, freq, phase, amp2, freq2, phase2
-uint BYTES_PER_INS[] = {8, 7, 13, 13, 17, 7, 13};
+uint BYTES_PER_INS[] = {8, 7, 13, 7, 13, 17, 13};
 
 // =============================================================================
 // Utility Functions

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -1175,6 +1175,9 @@ void loop() {
                                 "Invalid Command - \'mode\' must be defined before "
                                 "instructions can be set\n");
                         }
+                        if (timing) {
+                            set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                        }
                     }
                 }
             }
@@ -1307,6 +1310,9 @@ void loop() {
                             fast_serial_printf(
                                 "Invalid Command - \'mode\' must be defined before "
                                 "instructions can be set\n");
+                        }
+                        if (timing) {
+                            set_time(addr, time, ad9959.sweep_type, ad9959.channels);
                         }
                     }
                 }

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -840,6 +840,7 @@ void loop() {
         OK();
     } else if (strncmp(readstring, "getfreqs", 8) == 0) {
         measure_freqs();
+		OK();
     } else if (strncmp(readstring, "numtriggers", 11) == 0) {
         fast_serial_printf("%u\n", triggers);
     } else if (strncmp(readstring, "reset", 5) == 0) {

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -702,7 +702,7 @@ void set_phase_sweep_ins_from_buffer(uint addr, uint channel, char * buffer){
     set_phase_sweep_ins(addr, channel, pow_start, pow_end, delta, rate, ftw, asf);
     if (timing) {
         if (ad9959.sweep_type == PHASE2_MODE) {
-            memcpy(&time, &(buffer[15]), 4);
+            memcpy(&time, &(buffer[13]), 4);
         } else {
             memcpy(&time, &(buffer[7]), 4);
         }

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -647,10 +647,10 @@ void set_phase_sweep_ins(uint addr, uint channel, uint16_t pow_start, uint16_t p
 
     if (ad9959.sweep_type == PHASE2_MODE) {
         // set amp
-        ins[INS_PHASE_FTW] = AD9959_REG_ACR;
+        ins[INS_PHASE_FTW] = AD9959_REG_FTW;
         load_ftw(ftw, &(ins[INS_PHASE_FTW+1]));
 
-        ins[INS_PHASE_ACR] = AD9959_REG_POW;
+        ins[INS_PHASE_ACR] = AD9959_REG_ACR;
         load_acr(asf, &(ins[INS_PHASE_ACR+1]));
     }
 

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -444,12 +444,12 @@ void set_amp_sweep_ins_from_buffer(uint addr, uint channel, char * buffer){
     rate = buffer[6];
     if (ad9959.sweep_type == AMP2_MODE) {
         memcpy(&ftw, &(buffer[7]), 4);
-        memcpy(&pow, &(buffer[9]), 2);
+        memcpy(&pow, &(buffer[11]), 2);
     }
     set_amp_sweep_ins(addr, channel, asf_start, asf_end, delta, rate, ftw, pow);
     if (timing) {
         if (ad9959.sweep_type == AMP2_MODE) {
-            memcpy(&time, &(buffer[11]), 4);
+            memcpy(&time, &(buffer[13]), 4);
         } else {
             memcpy(&time, &(buffer[7]), 4);
         }
@@ -1118,7 +1118,6 @@ void loop() {
                 parsed = sscanf(readstring, "%*s %u %u %lf %lf %lf %u", &channel, &addr, &start,
                                 &end, &sweep_rate, &time);
             }
-            fast_serial_printf("%d\n", parsed);
 
             if (parsed == 1) {
                 fast_serial_printf("Missing Argument - expected: set <channel:int> ... \n");

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -1314,6 +1314,131 @@ void loop() {
                             }
                             addr++;
                         }
+                    } else if (ad9959.sweep_type == AMP_MODE) {
+                        uint32_t time;
+                        uint16_t asf_start, asf_end, delta;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&asf_start, &(readstring[byte_offset + 0]), 2);
+                                memcpy(&asf_end, &(readstring[byte_offset + 2]), 2);
+                                memcpy(&delta, &(readstring[byte_offset + 4]), 2);
+                                rate = readstring[byte_offset + 6];
+                                set_amp_sweep_ins(addr, j, asf_start, asf_end, delta, rate, 0, 0);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 7]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == AMP2_MODE) {
+                        uint32_t ftw, time;
+                        uint16_t asf_start, asf_end, delta, pow;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&asf_start, &(readstring[byte_offset + 0]), 2);
+                                memcpy(&asf_end, &(readstring[byte_offset + 2]), 2);
+                                memcpy(&delta, &(readstring[byte_offset + 4]), 2);
+                                rate = readstring[byte_offset + 6];
+                                memcpy(&ftw, &(readstring[byte_offset + 7]), 4);
+                                memcpy(&pow, &(readstring[byte_offset + 9]), 2);
+                                set_amp_sweep_ins(addr, j, asf_start, asf_end, delta, rate, ftw, pow);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 11]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == FREQ_MODE) {
+                        uint32_t ftw_start, ftw_end, delta, time;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&ftw_start, &(readstring[byte_offset + 0]), 4);
+                                memcpy(&ftw_end, &(readstring[byte_offset + 4]), 4);
+                                memcpy(&delta, &(readstring[byte_offset + 8]), 4);
+                                rate = readstring[byte_offset + 12];
+                                set_freq_sweep_ins(addr, j, ftw_start, ftw_end, delta, rate, 0, 0);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 13]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == FREQ2_MODE) {
+                        uint32_t ftw_start, ftw_end, delta, time;
+                        uint16_t asf, pow;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&ftw_start, &(readstring[byte_offset + 0]), 4);
+                                memcpy(&ftw_end, &(readstring[byte_offset + 4]), 4);
+                                memcpy(&delta, &(readstring[byte_offset + 8]), 4);
+                                rate = readstring[byte_offset + 12];
+                                memcpy(&asf, &(readstring[byte_offset + 13]), 2);
+                                memcpy(&pow, &(readstring[byte_offset + 15]), 2);
+                                set_freq_sweep_ins(addr, j, ftw_start, ftw_end, delta, rate, asf, pow);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 17]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == PHASE_MODE) {
+                        uint32_t time;
+                        uint16_t pow_start, pow_end, delta;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&pow_start, &(readstring[byte_offset + 0]), 2);
+                                memcpy(&pow_end, &(readstring[byte_offset + 2]), 2);
+                                memcpy(&delta, &(readstring[byte_offset + 4]), 2);
+                                rate = readstring[byte_offset + 6];
+                                set_phase_sweep_ins(addr, j, pow_start, pow_end, delta, rate, 0, 0);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 7]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == PHASE2_MODE) {
+                        uint32_t ftw, time;
+                        uint16_t asf, pow_start, pow_end, delta;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&pow_start, &(readstring[byte_offset + 0]), 2);
+                                memcpy(&pow_end, &(readstring[byte_offset + 2]), 2);
+                                memcpy(&delta, &(readstring[byte_offset + 4]), 2);
+                                rate = readstring[byte_offset + 6];
+                                memcpy(&ftw, &(readstring[byte_offset + 7]), 4);
+                                memcpy(&asf, &(readstring[byte_offset + 11]), 2);
+                                set_phase_sweep_ins(addr, j, pow_start, pow_end, delta, rate, ftw, asf);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 15]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
                     }
 
                     ins_count -= ins_per_buffer;
@@ -1341,8 +1466,133 @@ void loop() {
                             }
                             addr++;
                         }
+                    } else if (ad9959.sweep_type == AMP_MODE) {
+                        uint32_t time;
+                        uint16_t asf_start, asf_end, delta;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&asf_start, &(readstring[byte_offset + 0]), 2);
+                                memcpy(&asf_end, &(readstring[byte_offset + 2]), 2);
+                                memcpy(&delta, &(readstring[byte_offset + 4]), 2);
+                                rate = readstring[byte_offset + 6];
+                                set_amp_sweep_ins(addr, j, asf_start, asf_end, delta, rate, 0, 0);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 7]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == AMP2_MODE) {
+                        uint32_t ftw, time;
+                        uint16_t asf_start, asf_end, delta, pow;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&asf_start, &(readstring[byte_offset + 0]), 2);
+                                memcpy(&asf_end, &(readstring[byte_offset + 2]), 2);
+                                memcpy(&delta, &(readstring[byte_offset + 4]), 2);
+                                rate = readstring[byte_offset + 6];
+                                memcpy(&ftw, &(readstring[byte_offset + 7]), 4);
+                                memcpy(&pow, &(readstring[byte_offset + 9]), 2);
+                                set_amp_sweep_ins(addr, j, asf_start, asf_end, delta, rate, ftw, pow);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 11]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == FREQ_MODE) {
+                        uint32_t ftw_start, ftw_end, delta, time;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&ftw_start, &(readstring[byte_offset + 0]), 4);
+                                memcpy(&ftw_end, &(readstring[byte_offset + 4]), 4);
+                                memcpy(&delta, &(readstring[byte_offset + 8]), 4);
+                                rate = readstring[byte_offset + 12];
+                                set_freq_sweep_ins(addr, j, ftw_start, ftw_end, delta, rate, 0, 0);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 13]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == FREQ2_MODE) {
+                        uint32_t ftw_start, ftw_end, delta, time;
+                        uint16_t asf, pow;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&ftw_start, &(readstring[byte_offset + 0]), 4);
+                                memcpy(&ftw_end, &(readstring[byte_offset + 4]), 4);
+                                memcpy(&delta, &(readstring[byte_offset + 8]), 4);
+                                rate = readstring[byte_offset + 12];
+                                memcpy(&asf, &(readstring[byte_offset + 13]), 2);
+                                memcpy(&pow, &(readstring[byte_offset + 15]), 2);
+                                set_freq_sweep_ins(addr, j, ftw_start, ftw_end, delta, rate, asf, pow);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 17]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == PHASE_MODE) {
+                        uint32_t time;
+                        uint16_t pow_start, pow_end, delta;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&pow_start, &(readstring[byte_offset + 0]), 2);
+                                memcpy(&pow_end, &(readstring[byte_offset + 2]), 2);
+                                memcpy(&delta, &(readstring[byte_offset + 4]), 2);
+                                rate = readstring[byte_offset + 6];
+                                set_phase_sweep_ins(addr, j, pow_start, pow_end, delta, rate, 0, 0);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 7]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
+                    } else if (ad9959.sweep_type == PHASE2_MODE) {
+                        uint32_t ftw, time;
+                        uint16_t asf, pow_start, pow_end, delta;
+                        uint8_t rate;
+                        for (int i = 0; i < ins_per_buffer; i++) {
+                            for (int j = 0; j < ad9959.channels; j++) {
+                                uint byte_offset = bytes_per_ins*(i*ad9959.channels + j);
+                                memcpy(&pow_start, &(readstring[byte_offset + 0]), 2);
+                                memcpy(&pow_end, &(readstring[byte_offset + 2]), 2);
+                                memcpy(&delta, &(readstring[byte_offset + 4]), 2);
+                                rate = readstring[byte_offset + 6];
+                                memcpy(&ftw, &(readstring[byte_offset + 7]), 4);
+                                memcpy(&asf, &(readstring[byte_offset + 11]), 2);
+                                set_phase_sweep_ins(addr, j, pow_start, pow_end, delta, rate, ftw, asf);
+                                if (timing) {
+                                    memcpy(&time, &(readstring[byte_offset + 15]), 4);
+
+                                    set_time(addr, time, ad9959.sweep_type, ad9959.channels);
+                                }
+                            }
+                            addr++;
+                        }
                     }
-                }
+                } 
 
                 OK();
             }

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -30,6 +30,7 @@
 #include "hardware/flash.h"
 #include "hardware/pio.h"
 #include "hardware/spi.h"
+#include "pico/bootrom.h"
 #include "pico/multicore.h"
 #include "pico/stdlib.h"
 #include "trigger_timer.pio.h"
@@ -1015,6 +1016,8 @@ void loop() {
             multicore_fifo_push_blocking(1);
             OK();
         }
+    } else if (strncmp(readstring, "program", 7) == 0) {
+		reset_usb_boot(0, 0);
     } else {
         fast_serial_printf("Unrecognized Command: \"%s\"\n", readstring);
     }

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -251,7 +251,7 @@ bool set_ins(uint type, uint channel, uint addr, double s0, double e0, double de
     if (channel == 4 || channel == 5) {
         instructions[offset - 1] = 0x00;
         if (channel == 5)
-            // repeat instrcution
+            // repeat instruction
             instructions[offset] = 0xff;
         else
             // end instruction
@@ -898,7 +898,7 @@ void loop() {
             if (parsed > 1 && channel > 5) {
                 fast_serial_printf(
                     "Invalid Channel - expected 0-3 for channels or 4/5 for stop/repeat "
-                    "instrcution\n");
+                    "instruction\n");
             } else if (channel > 3 && parsed < 2) {
                 fast_serial_printf("Missing Argument - expected: set <channel:int> <addr:int> \n");
             } else if (!timing && parsed < 5 && channel < 4) {
@@ -930,7 +930,7 @@ void loop() {
             if (parsed > 1 && channel > 5) {
                 fast_serial_printf(
                     "Invalid Channel - expected 0-3 for channels or 4/5 for stop/repeat "
-                    "instrcution\n");
+                    "instruction\n");
             } else if (channel > 3 && parsed < 2) {
                 fast_serial_printf("Missing Argument - expected: set <channel:int> <addr:int> \n");
             } else if (parsed < 6 && channel < 4) {

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -824,6 +824,7 @@ void background() {
 // =============================================================================
 
 void loop() {
+    bzero(readstring, 256);
     fast_serial_read_until(readstring, 256, '\n');
     int local_status = get_status();
 
@@ -1058,7 +1059,7 @@ void loop() {
                     "instruction\n");
             } else if (channel > 3 && parsed < 2) {
                 fast_serial_printf("Missing Argument - expected: set <channel:int> <addr:int> \n");
-            } else if (timing && parsed < 6) {
+            } else if (channel < 4 && ((timing && parsed < 6) || (!timing && parsed < 5))) {
                 fast_serial_printf(
                     "Missing Argument - expected: set <channel:int> <addr:int> <frequency:double> "
                     "<amplitude:double> <phase:double> (<time:int>)\n");
@@ -1201,7 +1202,7 @@ void loop() {
                     "instruction\n");
             } else if (channel > 3 && parsed < 2) {
                 fast_serial_printf("Missing Argument - expected: set <channel:int> <addr:int> \n");
-            } else if (timing && parsed < 6) {
+            } else if (channel < 4 && ((timing && parsed < 6) || (!timing && parsed < 5))) {
                 fast_serial_printf(
                     "Missing Argument - expected: set <channel:int> <addr:int> <ftw:int32> "
                     "<asf:int16> <pow:int16> (<time:int>)\n");


### PR DESCRIPTION
This pull request attempts to resolve #35 and #44.

First, `set_ins` is split into different functions for different modes. Each of these functions is then split into a floating point to integer function (used by the `set` command) and an integer to SPI instruction function (used by the 'seti' command and binary programming).

Second, the `seti` (set-integer) command is added. This allows instructions to be programmed with integer values. The `set` command then has its separate `delta` and `rate` parameters combined into a single `sweep_rate` floating point parameter. This could be done in a way that allows for greater precision, but for the sort of testing `set` is likely to be used for, it may be fine as is.

Finally, the `setb` (set-binary) command is added. This allows instructions to be programmed in a large block without ascii encoding. The number of instructions is sent first, allowing the Pi Pico to check if there is enough memory available.