### PR TITLE
Channel mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If changing the reference clock and PLL multiplier, you should set the reference
 The AD9959's PLL has an output range of 100-160 MHz or 255-500 MHz with VCO gain enabled. The pico will automatically enable the VCO gain bit if the requested frequency is in the upper range. If trying to use the PLL multiplier to generate a frequency between 160 and 255 MHz, there is no guarantee of operation.
 
 * `setchannels <num:int>`:  
-Sets how many channels being used by the table mode. Uses the lowest channels first, starting with channel 0. If number of channels is set to `1`, buffered execution instructions will be written to all 4 channels simultaneously.
+Sets how many channels being used by the table mode. Uses the lowest channels first, starting with channel 0. If number of channels is set to `0`, buffered execution instructions will be written to all 4 channels simultaneously.
 
 * `mode <sweep-type:int> <trigger-source:int>`:  
 Configures what mode the DDS-Sweeper is operating in

--- a/dds-sweeper/ad9959.h
+++ b/dds-sweeper/ad9959.h
@@ -86,6 +86,7 @@ typedef struct ad9959_config {
     uint32_t pll_mult;
     int sweep_type;
     uint channels;
+    uint mirror;
 } ad9959_config;
 
 // get tuning words

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -171,6 +171,7 @@ void reset() {
     sync();
     ad9959.sweep_type = 1;
     ad9959.channels = 1;
+    ad9959.mirror = 0;
     INS_SIZE = 14;
 
     set_pll_mult(&ad9959, ad9959.pll_mult);
@@ -267,7 +268,7 @@ bool set_stop_instruction(uint addr){
 void set_ins_csr(uint8_t * ins, uint channel){
     // set csr
     ins[INS_CSR] = AD9959_REG_CSR;
-    if (ad9959.channels == 1) {
+    if (ad9959.mirror) {
         ins[INS_CSR+1] = 0xf2;
     } else {
         ins[INS_CSR+1] = (1u << (channel + 4)) | 0x02;
@@ -285,7 +286,7 @@ void set_ins_sweeps(uint addr, uint channel, bool rising){
     // The least significant 4 bits in the byte correspond to the first value the
     // profile pin hits during an update. Since the pin should always go high first,
     // that means the least significant nibble should always be 0xf.
-    if (rising && ad9959.channels == 1) {
+    if (rising && ad9959.mirror) {
         // case: upward sweep single channel mode
         instructions[offset] = 0xff;
     } else if (rising) {
@@ -296,7 +297,7 @@ void set_ins_sweeps(uint addr, uint channel, bool rising){
         else {
             instructions[offset] |= (1u << (3 - channel)) | (1u << (7 - channel));
         }
-    } else if (ad9959.channels == 1) {
+    } else if (ad9959.mirror) {
         // case: downward sweep single channel mode
         instructions[offset] = 0x0f;
     } else {
@@ -887,10 +888,17 @@ void loop() {
 
         if (parsed < 1) {
             fast_serial_printf("Missing Argument - expected: setchannels <num:int>\n");
-        } else if (channels < 1 || channels > 4) {
-            fast_serial_printf("Invalid Channels - expected: num must be in range 0-3\n");
+        } else if (channels < 0 || channels > 4) {
+            fast_serial_printf("Invalid Channels - expected: num must be in range 0-4\n");
         } else {
-            ad9959.channels = channels;
+            if (channels == 0) {
+                // mirror commands to all channels
+                ad9959.channels = 1;
+                ad9959.mirror = 1;
+            } else {
+                ad9959.channels = channels;
+                ad9959.mirror = 0;
+            }
             OK();
         }
     } else if (strncmp(readstring, "setfreq", 7) == 0) {


### PR DESCRIPTION
Fixes #52 

Modifies `setchannels` to take 0 as an input that indicates all outputs should have the same output. `setchannels 1` will now only output on channel 0.

Will probably mess with testing notebooks.

Compiles, but not tested on hardware.