### PR TITLE
Adding more debug commands to view instructions

### DIFF
--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -743,6 +743,7 @@ void get_instructions(void) {
 
     uint step = INS_SIZE * ad9959.channels + 1; // INS_SIZE changes for instruction type
     uint num_ins = 0;
+    uint chan_addr_offset = 4; // CHECK
 
     // Count valid instructions
     while (num_ins < MAX_SIZE / step) {
@@ -752,10 +753,13 @@ void get_instructions(void) {
         num_ins++;
     }
 
-    // Loop out raw instruction bytes 
+    // Loop through each instruction line to get raw bytes 
     for (uint i = 0; i < num_ins; i++) {
         uint offset = i * step;
+        offset += chan_addr_offset; // CHECK
+
         fast_serial_printf("Offset is: %u | ", offset);
+        fast_serial_printf("Step is: %u | ", step);
         fast_serial_printf("Raw bytes for instruction %u: ", i);
         for (uint j = 0; j < step; j++) {
             fast_serial_printf("%02X ", instructions[offset + j]);

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -739,7 +739,6 @@ void parse_phase_sweep_ins(uint addr, uint channel,
 }
 
 void get_instructions(void) {
-    // Just trying to get this up and running for setb single stepping
     fast_serial_printf("Instruction Table Dump:\n");
 
     uint step = INS_SIZE * ad9959.channels + 1; // INS_SIZE changes for instruction type
@@ -755,35 +754,69 @@ void get_instructions(void) {
 
     for (uint i = 0; i < num_ins; i++) {
         uint offset = i * step;
-        uint chan_addr_offset = 3;
+        // uint chan_addr_offset = 3 + 1;
+        // offset += chan_addr_offset;
+
+        fast_serial_printf("Offset is: %u | ", offset);
+
+        fast_serial_printf("Raw bytes for instruction %u: ", i);
+        for (uint j = 0; j < step; j++) {
+            fast_serial_printf("%02X ", instructions[offset + j]);
+        }
+        fast_serial_printf("\n");
+
+    }
+
+    fast_serial_printf("End of Instruction Table\n");
+}
+
+void get_memory_layout(void) {
+    // Currently trying single step mode
+    fast_serial_printf("Instruction Table Dump:\n");
+
+    uint step = INS_SIZE * ad9959.channels + 1; // INS_SIZE changes for instruction type
+    uint num_ins = 0;
+
+    // Count valid instructions
+    while (num_ins < MAX_SIZE / step) {
+        if (instructions[num_ins * step] == 0x00) {
+            break;
+        }
+        num_ins++;
+    }
+
+    for (uint i = 0; i < num_ins; i++) {
+        uint offset = i * step;
+        // uint chan_addr_offset = 3 + 1;
 
         // test if i need to skip three (instructions are 15 large? tuning words are 12 bytes)
-        offset += chan_addr_offset;
+        // offset += chan_addr_offset;
 
-        // fast_serial_printf("Offset is: %u ||", offset);
+        fast_serial_printf("Intructio is: %u | ", offset);
 
-        // fast_serial_printf("Raw bytes for instruction %u: ", i);
-        // for (uint j = 0; j < step; j++) {
-        //     fast_serial_printf("%02X ", instructions[offset + j]);
-        // }
-        // fast_serial_printf("\n");
+        fast_serial_printf("Raw bytes for instruction %u: ", i);
+        for (uint j = 0; j < step; j++) {
+            fast_serial_printf("%02X ", instructions[offset + j]);
+        }
+        fast_serial_printf("\n");
 
-        uint32_t ftw, time;
-        uint16_t asf, pow;
+        // uint32_t ftw, time;
+        // uint16_t asf, pow;
         
-        // byte alignment for single step ins -- note that this is not general yet
-        memcpy(&ftw,  &instructions[offset + 0], 4);  // Frequency Tuning Word
-        memcpy(&asf,  &instructions[offset + 4], 2);  // Amplitude Scale Factor
-        memcpy(&pow,  &instructions[offset + 6], 2);  // Phase Offset Word
-        memcpy(&time, &instructions[offset + 8], 4);  // Time
+        // // byte alignment for single step ins -- note that this is not general yet
+        // memcpy(&ftw,  &instructions[offset + 0], 4);  // Frequency Tuning Word
+        // memcpy(&asf,  &instructions[offset + 4], 2);  // Amplitude Scale Factor
+        // memcpy(&pow,  &instructions[offset + 6], 2);  // Phase Offset Word
+        // // memcpy(&pow,  &instructions[offset + 5], 2);  // Phase Offset Word
+        // memcpy(&time, &instructions[offset + 8], 4);  // Time
 
-        // // Convert byte order to little-endian
-        ftw = __builtin_bswap32(ftw);
-        asf = __builtin_bswap16(asf);
-        pow = __builtin_bswap16(pow);
-        time = __builtin_bswap32(time);
+        // // // Convert byte order to little-endian
+        // ftw = __builtin_bswap32(ftw);
+        // asf = __builtin_bswap16(asf);
+        // pow = __builtin_bswap16(pow);
+        // time = __builtin_bswap32(time);
 
-        fast_serial_printf("Instruction %u: %u %u %u %u\n", i, ftw, asf, pow, time);
+        // fast_serial_printf("Instruction %u: %u %u %u %u\n", i, ftw, asf, pow, time);
 
         // // get memory layout/format
         // fast_serial_printf("Instruction format: %02X %02X %02X %02X | %02X %02X | %02X %02X | %02X %02X %02X %02X\n",
@@ -795,18 +828,6 @@ void get_instructions(void) {
 
     fast_serial_printf("End of Instruction Table\n");
 }
-
-// void get_instructions(const *buffer, uint32_t buffer_size ) {
-//     // Just trying to get this up and running for setb single stepping
-    
-//     // get buffer
-
-//     // get buffersize
-
-//     fast_serial_printf("Instruction Table Dump:\n");
-//     fast_serial_write(buffer, buffer_size);
-//     fast_serial_printf("End of Instruction Table\n");
-// }
 
 // =============================================================================
 // Table Running Loop

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -752,81 +752,100 @@ void get_instructions(void) {
         num_ins++;
     }
 
+    // Loop out raw instruction bytes 
     for (uint i = 0; i < num_ins; i++) {
         uint offset = i * step;
-        // uint chan_addr_offset = 3 + 1;
-        // offset += chan_addr_offset;
-
         fast_serial_printf("Offset is: %u | ", offset);
-
         fast_serial_printf("Raw bytes for instruction %u: ", i);
         for (uint j = 0; j < step; j++) {
             fast_serial_printf("%02X ", instructions[offset + j]);
         }
         fast_serial_printf("\n");
-
     }
 
     fast_serial_printf("End of Instruction Table\n");
 }
 
-void get_memory_layout(void) {
-    // Currently trying single step mode
-    fast_serial_printf("Instruction Table Dump:\n");
+void get_memory_layout(uint sweep_mode) {
 
-    uint step = INS_SIZE * ad9959.channels + 1; // INS_SIZE changes for instruction type
-    uint num_ins = 0;
-
-    // Count valid instructions
-    while (num_ins < MAX_SIZE / step) {
-        if (instructions[num_ins * step] == 0x00) {
+    // Each prints with timing since it's trivial to remove
+    char datatypes[1024] = "";
+    switch (sweep_mode) {
+        case 0:
+            fast_serial_printf("Mode 0 - Single Steps\n");
+            strcat(datatypes, "datatypes = np.dtype(["
+                            "('frequency', np.uint32), "
+                            "('amplitude', np.uint16), "
+                            "('phase', np.uint16), "
+                            "('time', np.uint32)])\n");
             break;
-        }
-        num_ins++;
-    }
-
-    for (uint i = 0; i < num_ins; i++) {
-        uint offset = i * step;
-        // uint chan_addr_offset = 3 + 1;
-
-        // test if i need to skip three (instructions are 15 large? tuning words are 12 bytes)
-        // offset += chan_addr_offset;
-
-        fast_serial_printf("Intructio is: %u | ", offset);
-
-        fast_serial_printf("Raw bytes for instruction %u: ", i);
-        for (uint j = 0; j < step; j++) {
-            fast_serial_printf("%02X ", instructions[offset + j]);
-        }
-        fast_serial_printf("\n");
-
-        // uint32_t ftw, time;
-        // uint16_t asf, pow;
+        case 1:
+            fast_serial_printf("Mode 1 - Amplitude Sweeps\n");
+            strcat(datatypes, "datatypes = np.dtype(["
+                            "('start amplitude', np.uint16), "
+                            "('stop amplitude', np.uint16), "
+                            "('delta', np.uint16), "
+                            "('rate', np.uint8), "
+                            "('time', np.uint32)])\n");
+            break;
+        case 2:
+            fast_serial_printf("Mode 2 - Frequency Sweeps\n");
+            strcat(datatypes, "datatypes = np.dtype(["
+                            "('start frequency', np.uint32), "
+                            "('stop frequency', np.uint32), "
+                            "('delta', np.uint32), "
+                            "('rate', np.uint8), "
+                            "('time', np.uint32)])\n");
+            break;
+        case 3:
+            fast_serial_printf("Mode 3 - Phase Sweeps\n");
+            strcat(datatypes, "datatypes = np.dtype(["
+                            "('start phase', np.uint16), "
+                            "('stop phase', np.uint16), "
+                            "('delta', np.uint16), "
+                            "('rate', np.uint8), "
+                            "('time', np.uint32)])\n");
+            break;
+        case 4:
+            fast_serial_printf("Mode 4 - Amplitude2 Sweeps\n");
+            strcat(datatypes, "datatypes = np.dtype(["
+                            "('start amplitude', np.uint16), "
+                            "('stop amplitude', np.uint16), "
+                            "('delta', np.uint16), "
+                            "('rate', np.uint8), "
+                            "('frequency', np.uint32), "
+                            "('phase', np.uint16), "
+                            "('time', np.uint32)])\n");
+            break;
+        case 5:
+            fast_serial_printf("Mode 5 - Frequency2 Sweeps\n");
+            strcat(datatypes, "datatypes = np.dtype(["
+                            "('start frequency', np.uint32), "
+                            "('stop frequency', np.uint32), "
+                            "('delta', np.uint32), "
+                            "('rate', np.uint8), "
+                            "('amplitude', np.uint16), "
+                            "('phase', np.uint16), "
+                            "('time', np.uint32)])\n");
+            break;
+        case 6:
+            fast_serial_printf("Mode 6 - Phase2 Sweeps\n");
+            strcat(datatypes, "datatypes = np.dtype(["
+                            "('start phase', np.uint16), "
+                            "('stop phase', np.uint16), "
+                            "('delta', np.uint16), "
+                            "('rate', np.uint8), "
+                            "('frequency', np.uint32), "
+                            "('amplitude', np.uint16), "
+                            "('time', np.uint32)])\n");
+            break;
         
-        // // byte alignment for single step ins -- note that this is not general yet
-        // memcpy(&ftw,  &instructions[offset + 0], 4);  // Frequency Tuning Word
-        // memcpy(&asf,  &instructions[offset + 4], 2);  // Amplitude Scale Factor
-        // memcpy(&pow,  &instructions[offset + 6], 2);  // Phase Offset Word
-        // // memcpy(&pow,  &instructions[offset + 5], 2);  // Phase Offset Word
-        // memcpy(&time, &instructions[offset + 8], 4);  // Time
-
-        // // // Convert byte order to little-endian
-        // ftw = __builtin_bswap32(ftw);
-        // asf = __builtin_bswap16(asf);
-        // pow = __builtin_bswap16(pow);
-        // time = __builtin_bswap32(time);
-
-        // fast_serial_printf("Instruction %u: %u %u %u %u\n", i, ftw, asf, pow, time);
-
-        // // get memory layout/format
-        // fast_serial_printf("Instruction format: %02X %02X %02X %02X | %02X %02X | %02X %02X | %02X %02X %02X %02X\n",
-        //     instructions[offset + 0], instructions[offset + 1], instructions[offset + 2], instructions[offset + 3],
-        //     instructions[offset + 4], instructions[offset + 5],
-        //     instructions[offset + 6], instructions[offset + 7],
-        //     instructions[offset + 8], instructions[offset + 9], instructions[offset + 10], instructions[offset + 11]);
+        default:
+            fast_serial_printf("Couldn't find mode info\n");
     }
+    fast_serial_printf("Active channels: %d\n", ad9959.channels);
+    fast_serial_printf("%s\n", datatypes);
 
-    fast_serial_printf("End of Instruction Table\n");
 }
 
 // =============================================================================
@@ -958,7 +977,8 @@ void loop() {
         OK();
     } else if (strncmp(readstring, "readtable", 9) == 0) {
         get_instructions();
-        // get_instructions(instructions, 64 * 8);
+    } else if (strncmp(readstring, "getmode", 7) == 0) {
+        get_memory_layout(ad9959.sweep_type);
     } else if (strncmp(readstring, "load", 4) == 0) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overread"

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -755,9 +755,9 @@ void get_instructions(void) {
 
     for (uint i = 0; i < num_ins; i++) {
         uint offset = i * step;
-        uint chan_addr_offset = 2;
+        uint chan_addr_offset = 3;
 
-        // test if i need to skip two
+        // test if i need to skip three (instructions are 15 large? tuning words are 12 bytes)
         offset += chan_addr_offset;
 
         // fast_serial_printf("Offset is: %u ||", offset);
@@ -785,12 +785,12 @@ void get_instructions(void) {
 
         fast_serial_printf("Instruction %u: %u %u %u %u\n", i, ftw, asf, pow, time);
 
-        // get memory layout/format
-        fast_serial_printf("Instruction format: %02X %02X %02X %02X | %02X %02X | %02X %02X | %02X %02X %02X %02X\n",
-            instructions[offset + 0], instructions[offset + 1], instructions[offset + 2], instructions[offset + 3],
-            instructions[offset + 4], instructions[offset + 5],
-            instructions[offset + 6], instructions[offset + 7],
-            instructions[offset + 8], instructions[offset + 9], instructions[offset + 10], instructions[offset + 11]);
+        // // get memory layout/format
+        // fast_serial_printf("Instruction format: %02X %02X %02X %02X | %02X %02X | %02X %02X | %02X %02X %02X %02X\n",
+        //     instructions[offset + 0], instructions[offset + 1], instructions[offset + 2], instructions[offset + 3],
+        //     instructions[offset + 4], instructions[offset + 5],
+        //     instructions[offset + 6], instructions[offset + 7],
+        //     instructions[offset + 8], instructions[offset + 9], instructions[offset + 10], instructions[offset + 11]);
     }
 
     fast_serial_printf("End of Instruction Table\n");

--- a/testing/KeysightScope.py
+++ b/testing/KeysightScope.py
@@ -1,0 +1,69 @@
+import pyvisa
+
+class KeysightScope:
+    """
+    Helper class using pyvisa for a USB connected Keysight Oscilloscope 
+    """
+    def __init__(self, 
+                 addr='USB?*::INSTR',
+                 timeout=1, 
+                 termination='\n'
+                 ):
+        rm = pyvisa.ResourceManager()
+        devs = rm.list_resources(addr)
+        assert len(devs), "pyvisa didn't find any connected devices matching " + addr
+        self.dev = rm.open_resource(devs[0])
+        self.dev.timeout = 15_000 * timeout
+        self.dev.read_termination = termination
+        self.idn = self.dev.query('*IDN?')
+        self.read = self.dev.read
+        self.write = self.dev.write
+        self.query = self.dev.query
+
+    def _get_screenshot(self, verbose=False):
+        if verbose == True:
+            print('Acquiring screen image...')
+        return(self.dev.query_binary_values(':DISPlay:DATA? PNG, COLor', datatype='s'))
+
+    def save_screenshot(self, filepath: str, verbose=False, inksaver=False):
+        if verbose == True:
+            print('Saving screen image...')
+        result = self._get_screenshot()
+
+        # Keysight scope defaults to inksaving for image save
+        if inksaver == True:
+            self.dev.write(':HARDcopy:INKSaver 1')
+        else: 
+            self.dev.write(':HARDcopy:INKSaver OFF')
+
+        with open(f'{filepath}', 'wb+') as ofile:
+            ofile.write(bytes(result))
+
+    def set_time_delay(self, time: float):
+        
+        self.write(f':TIMebase:DELay {time}')
+
+    def set_time_scale(self, time: float):
+        self.write(f':TIMebase:SCALe {time}')
+
+    def annotate_screen(self, message: str):
+        self.write(f':DISPlay:ANNotation:TEXT "{message}"')
+
+    def set_math_scale(self, scale: float):
+        self.write(f'FUNCtion:SCALe {scale}')
+
+    def set_math_offset(self, offset: float):
+        self.write(f'FUNCtion:OFFSet {offset}')
+
+    def channel_state(self, channel: int, state: int):
+        """
+        Turn on or off a channel
+        state: int (ON: 1 or OFF: 0)
+        """
+        self.write(f':CHANnel{channel}:DISPlay {state}')
+
+    def set_channel_offset(self, channel: int, y_offset: float):
+        self.write(f':CHANnel{channel}:OFFSet {y_offset}')
+
+    def set_channel_scale(self, channel: int, y_scale: float):
+        self.write(f':CHANnel{channel}:SCALe {y_scale}')

--- a/testing/binary-tests.ipynb
+++ b/testing/binary-tests.ipynb
@@ -101,9 +101,14 @@
    "outputs": [],
    "source": [
     "class Binary_Routines():\n",
+    "    \"\"\"\n",
+    "    Class handler for `setb` command to send binary tables to the dds-sweeper\n",
+    "    \"\"\"\n",
+    "\n",
     "    def __init__(self):\n",
     "        self.mirror_channels = False\n",
     "        self.debug_run = True\n",
+    "        self.MAX_SIZE = 256\n",
     "\n",
     "    def catch_response(self):\n",
     "        resp = conn.readline().decode().strip()\n",
@@ -115,6 +120,10 @@
     "\n",
     "    def debug_on(self):\n",
     "        conn.write(b'debug on\\n')\n",
+    "        self.assert_OK()\n",
+    "\n",
+    "    def debug_off(self):\n",
+    "        conn.write(b'debug off\\n')\n",
     "        self.assert_OK()\n",
     "\n",
     "    def set_mode(self, sweep_mode: int, timing_mode: int, num_channels: int):\n",
@@ -154,6 +163,32 @@
     "        if self.debug_run == True:\n",
     "            print('table executed')\n",
     "\n",
+    "    def read_table(self):\n",
+    "        conn.write(b'readtable\\n')\n",
+    "        for _ in range(self.MAX_SIZE):\n",
+    "            resp = self.catch_response()\n",
+    "            print(resp)\n",
+    "            if \"End of\" in resp:\n",
+    "                break\n",
+    "            elif \"Cannot\" in resp:\n",
+    "                break\n",
+    "            elif len(resp) == 0:\n",
+    "                break\n",
+    "        # self.assert_OK, 'something went wrong reading table'\n",
+    "\n",
+    "    def get_memory_layout(self):\n",
+    "        conn.write(b'getmode\\n')\n",
+    "        # self.assert_OK, \n",
+    "        # self.assert_OK, 'something went wrong getting memory layout'\n",
+    "        mode = self.catch_response()\n",
+    "        channels = self.catch_response()\n",
+    "        memory_layout = self.catch_response()\n",
+    "        print(f\"mode {mode}\")\n",
+    "        print(channels)\n",
+    "        print(memory_layout)\n",
+    "        # self.assert_OK, 'something went wrong getting memory layout'\n",
+    "\n",
+    "        \n",
     "Binary_Routine_Test = Binary_Routines()"
    ]
   },
@@ -203,13 +238,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt = np.dtype([('frequency', np.uint32), ('amplitude', np.uint16), ('phase', np.uint16), ('time', np.uint32)])\n",
-    "# dt = np.dtype([\n",
-    "#     ('frequency', '>u4'),  # Big-endian uint32\n",
-    "#     ('amplitude', '>u2'),  # Big-endian uint16\n",
-    "#     ('phase', '>u2'),      # Big-endian uint16\n",
-    "#     ('time', '>u4')        # Big-endian uint32\n",
-    "# ])\n",
+    "dt = np.dtype([('frequency', np.uint32), \n",
+    "               ('amplitude', np.uint16), \n",
+    "               ('phase', np.uint16), \n",
+    "               ('time', np.uint32)])\n",
+    "\n",
     "f1 = get_ftw(freq_out = 100 * MHZ)\n",
     "f2 = get_ftw(freq_out = 120 * MHZ)\n",
     "f3 = get_ftw(freq_out = 110 * MHZ)\n",
@@ -260,7 +293,6 @@
     }
    ],
    "source": [
-    "# single_step_test.catch_response()\n",
     "single_step_test.set_mode(sweep_mode=0, timing_mode=1, num_channels=1)\n",
     "single_step_test.allocate(start_address=0, instructions=step_instructions)\n",
     "single_step_test.table_to_memory(instructions=step_instructions)\n",
@@ -273,9 +305,22 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Instruction Table Dump:\n",
+      "Offset is: 0 | Raw bytes for instruction 0: 7F 00 F2 04 3D 70 A3 D7 05 10 00 06 00 13 FF\n",
+      "Offset is: 15 | Raw bytes for instruction 1: 01 00 F2 04 38 51 EB 85 05 10 00 06 00 11 F4\n",
+      "Offset is: 30 | Raw bytes for instruction 2: 05 00 F2 04 33 33 33 33 05 10 00 06 00 13 FF\n",
+      "Offset is: 45 | Raw bytes for instruction 3: 01 00 F2 04 38 51 EB 85 05 10 00 06 00 13 FF\n",
+      "End of Instruction Table\n"
+     ]
+    }
+   ],
    "source": [
-    "# Binary_Routine_Test.catch_response()"
+    "single_step_test.read_table()"
    ]
   },
   {
@@ -284,122 +329,22 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "10"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mode Mode 0 - Single Steps\n",
+      "Active channels: 1\n",
+      "datatypes = np.dtype([('frequency', np.uint32), ('amplitude', np.uint16), ('phase', np.uint16), ('time', np.uint32)])\n"
+     ]
     }
    ],
    "source": [
-    "conn.write(b'readtable\\n')"
+    "single_step_test.get_memory_layout()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# conn.write(b'program\\n')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4096"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "p1"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0x33333333\n",
-      "0x3d70a3d7\n",
-      "0x3851eb85\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(hex(f1))\n",
-    "print(hex(f2))\n",
-    "print(hex(f3))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0x3ff\n",
-      "0x1f4\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(hex(1023))\n",
-    "print(hex(500))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Instruction Table Dump:\n",
-      "Offset is: 0 ||Raw bytes for instruction 0: 3F 00 F2 04 3D 70 A3 D7 05 10 00 06 00 13 FF\n",
-      "Offset is: 15 ||Raw bytes for instruction 1: 01 00 F2 04 38 51 EB 85 05 10 00 06 00 11 F4\n",
-      "Offset is: 30 ||Raw bytes for instruction 2: 05 00 F2 04 33 33 33 33 05 10 00 06 00 13 FF\n",
-      "Offset is: 45 ||Raw bytes for instruction 3: 01 00 F2 04 38 51 EB 85 05 10 00 06 00 13 FF\n",
-      "End of Instruction Table\n"
-     ]
-    }
-   ],
-   "source": [
-    "MAX_SIZE = 256\n",
-    "# for _ in range(step_instructions.shape[0] + 2): # + 2 to catch header and footer\n",
-    "for _ in range(MAX_SIZE):\n",
-    "    resp = Binary_Routine_Test.catch_response()\n",
-    "    print(resp)\n",
-    "    if \"End of\" in resp:\n",
-    "        break\n",
-    "    elif \"Cannot\" in resp:\n",
-    "        break\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -408,13 +353,13 @@
        "''"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Binary_Routine_Test.catch_response()"
+    "single_step_test.catch_response()"
    ]
   },
   {
@@ -433,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +413,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -486,8 +431,6 @@
    ],
    "source": [
     "freq_sweep_test = Binary_Routines()\n",
-    "# print(freq_sweep_test.catch_response())\n",
-    "# freq_sweep_test.debug_on()\n",
     "freq_sweep_test.set_mode(sweep_mode=2, timing_mode=1, num_channels=1)\n",
     "freq_sweep_test.allocate(start_address=0, instructions=freq_sweep_table)\n",
     "freq_sweep_test.table_to_memory(instructions=freq_sweep_table)\n",
@@ -497,27 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "10"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "conn.write(b'readtable\\n')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -525,30 +448,41 @@
      "output_type": "stream",
      "text": [
       "Instruction Table Dump:\n",
-      "Offset is: 0 ||Raw bytes for instruction 0: FF 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is: 30 ||Raw bytes for instruction 1: FF 00 F2 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 60 ||Raw bytes for instruction 2: 0F 00 F2 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 90 ||Raw bytes for instruction 3: 0F 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
-      "Offset is: 120 ||Raw bytes for instruction 4: 0F 00 F2 04 3D 70 A3 D7 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 150 ||Raw bytes for instruction 5: 0F 00 F2 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is: 180 ||Raw bytes for instruction 6: 0F 00 F2 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is: 210 ||Raw bytes for instruction 7: FF 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 240 ||Raw bytes for instruction 8: 0F 00 F2 04 38 51 EB 85 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 270 ||Raw bytes for instruction 9: 0F 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
+      "Offset is: 0 | Raw bytes for instruction 0: FF 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is: 30 | Raw bytes for instruction 1: FF 00 F2 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 60 | Raw bytes for instruction 2: 0F 00 F2 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 90 | Raw bytes for instruction 3: 0F 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
+      "Offset is: 120 | Raw bytes for instruction 4: 0F 00 F2 04 3D 70 A3 D7 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 150 | Raw bytes for instruction 5: 0F 00 F2 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is: 180 | Raw bytes for instruction 6: 0F 00 F2 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is: 210 | Raw bytes for instruction 7: FF 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 240 | Raw bytes for instruction 8: 0F 00 F2 04 38 51 EB 85 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 270 | Raw bytes for instruction 9: 0F 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
       "End of Instruction Table\n"
      ]
     }
    ],
    "source": [
-    "MAX_SIZE = 256\n",
-    "# for _ in range(step_instructions.shape[0] + 2): # + 2 to catch header and footer\n",
-    "for _ in range(MAX_SIZE):\n",
-    "    resp = Binary_Routine_Test.catch_response()\n",
-    "    print(resp)\n",
-    "    if \"End of\" in resp:\n",
-    "        break\n",
-    "    elif \"Cannot\" in resp:\n",
-    "        break"
+    "freq_sweep_test.read_table()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mode Mode 2 - Frequency Sweeps\n",
+      "Active channels: 1\n",
+      "datatypes = np.dtype([('start frequency', np.uint32), ('stop frequency', np.uint32), ('delta', np.uint32), ('rate', np.uint8),\n"
+     ]
+    }
+   ],
+   "source": [
+    "freq_sweep_test.get_memory_layout()"
    ]
   },
   {
@@ -567,15 +501,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt = np.dtype([('start phase', np.uint16), \n",
-    "               ('stop phase', np.uint16), \n",
-    "               ('delta', np.uint16), \n",
-    "               ('rate', np.uint8), \n",
-    "               ('time', np.uint32)])\n",
+    "for i in range(4):\n",
+    "    conn.write(b'setfreq %d 100000000\\n' % i)\n",
+    "    Binary_Routine_Test.catch_response()\n",
+    "\n",
+    "    conn.write(b'setphase %d 0\\n' % i)\n",
+    "    Binary_Routine_Test.catch_response()\n",
+    "\n",
+    "dt = np.dtype([('start phase0', np.uint16), \n",
+    "               ('stop phase0', np.uint16), \n",
+    "               ('delta0', np.uint16), \n",
+    "               ('rate0', np.uint8),\n",
+    "               ('time0', np.uint32),\n",
+    "               ('start phase1', np.uint16), \n",
+    "               ('stop phase1', np.uint16), \n",
+    "               ('delta1', np.uint16), \n",
+    "               ('rate1', np.uint8), \n",
+    "               ('time1', np.uint32)])\n",
     "\n",
     "p0 = get_pow(phase = 0)\n",
     "p1 = get_pow(phase = 90)\n",
@@ -588,45 +534,40 @@
     "t = 2\n",
     "\n",
     "\n",
-    "channel0_instructions = np.array([\n",
-    "                                (0, 0, d, r, t),\n",
-    "                                (0, 0, d, r, t),\n",
-    "                                (0, 0, d, r, t),\n",
-    "                                (0, 0, d, r, t),\n",
-    "                                (0, 0, d, r, t),\n",
-    "                                (0, 0, d, r, t)\n",
-    "                                # (p0, p2, d, r, t),\n",
-    "                                # (p2, p1, d, r, t),\n",
-    "                                # (p1, p0, d, r, t),\n",
-    "                                # (p0, p1, d, r, t),\n",
-    "                                # (p1, p2, d, r, t),\n",
-    "                                # (p2, p0, d, r, t)\n",
+    "phase_sweep_instructions = np.array([\n",
+    "                                    (0, 0, d, r, t, p0, p2, d, r, t),\n",
+    "                                    (0, 0, d, r, t, p2, p1, d, r, t),\n",
+    "                                    (0, 0, d, r, t, p1, p0, d, r, t),\n",
+    "                                    (0, 0, d, r, t, p0, p1, d, r, t),\n",
+    "                                    (0, 0, d, r, t, p1, p2, d, r, t),\n",
+    "                                    (0, 0, d, r, t, p2, p0, d, r, t),\n",
     "                                 ]\n",
-    "                                 , dtype = dt)\n",
-    "\n",
-    "channel1_instructions = np.array([\n",
-    "                                # (0, 180, d, r, t),\n",
-    "                                # (180, 90, d, r, t),\n",
-    "                                # (90, 0, d, r, t),\n",
-    "                                # (0, 90, d, r, t),\n",
-    "                                # (90, 180, d, r, t),\n",
-    "                                # (180, p0, d, r, t)\n",
-    "                                (p0, p2, d, r, t),\n",
-    "                                (p2, p1, d, r, t),\n",
-    "                                (p1, p0, d, r, t),\n",
-    "                                (p0, p1, d, r, t),\n",
-    "                                (p1, p2, d, r, t),\n",
-    "                                (p2, p0, d, r, t)\n",
-    "                                 ]\n",
-    "                                 , dtype = dt)\n",
-    "\n",
-    "\n",
-    "phase_sweep_instructions = np.concatenate((channel0_instructions, channel1_instructions))"
+    "                                 , dtype = dt)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Binary_Routine_Test.catch_response()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -644,63 +585,38 @@
    ],
    "source": [
     "phase_sweep_test = Binary_Routines()\n",
-    "phase_sweep_test.debug_on()\n",
+    "phase_sweep_test.debug_off()\n",
     "phase_sweep_test.set_mode(sweep_mode=3, timing_mode=1, num_channels=2)\n",
     "\n",
-    "phase_sweep_test.allocate(start_address=0, instructions=channel0_instructions)\n",
+    "phase_sweep_test.allocate(start_address=0, instructions=phase_sweep_instructions)\n",
     "phase_sweep_test.table_to_memory(instructions=phase_sweep_instructions)\n",
     "\n",
-    "# phase_sweep_test.allocate(channel=1, instructions=channel1_instructions)\n",
-    "# phase_sweep_test.table_to_memory(instructions=channel1_instructions)\n",
-    "\n",
-    "phase_sweep_test.end_table(instructions=channel0_instructions)\n",
+    "phase_sweep_test.end_table(instructions=phase_sweep_instructions)\n",
     "phase_sweep_test.start_routine()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# phase_sweep_test = Binary_Routines()\n",
-    "# phase_sweep_test.debug_on()\n",
-    "# phase_sweep_test.set_mode(sweep_mode=3, timing_mode=1, num_channels=0)\n",
-    "\n",
-    "# phase_sweep_test.allocate(start_address=0, instructions=channel0_instructions)\n",
-    "# phase_sweep_test.table_to_memory(instructions=channel0_instructions)\n",
-    "\n",
-    "# # phase_sweep_test.allocate(channel=1, instructions=channel1_instructions)\n",
-    "# # phase_sweep_test.table_to_memory(instructions=channel1_instructions)\n",
-    "\n",
-    "# phase_sweep_test.end_table(instructions=channel0_instructions)\n",
-    "# phase_sweep_test.start_routine()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "10"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mode Mode 3 - Phase Sweeps\n",
+      "Active channels: 2\n",
+      "datatypes = np.dtype([('start phase', np.uint16), ('stop phase', np.uint16), ('delta', np.uint16), ('rate', np.uint8), ('time',\n"
+     ]
     }
    ],
    "source": [
-    "conn.write(b'readtable\\n')\n",
-    "# phase_sweep_test.assert_OK()"
+    "phase_sweep_test.get_memory_layout()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -708,31 +624,44 @@
      "output_type": "stream",
      "text": [
       "Instruction Table Dump:\n",
-      "Offset is: 0 ||Raw bytes for instruction 0: 3F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10\n",
-      "Offset is: 55 ||Raw bytes for instruction 1: 1F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10\n",
-      "Offset is: 110 ||Raw bytes for instruction 2: 0C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10\n",
-      "Offset is: 165 ||Raw bytes for instruction 3: AC 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
-      "Offset is: 220 ||Raw bytes for instruction 4: 4D 00 12 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 40 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 40 00 00 00 03 C0 43 10\n",
-      "Offset is: 275 ||Raw bytes for instruction 5: BF 00 12 05 10 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
+      "Offset is: 0 | Raw bytes for instruction 0: 7F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10\n",
+      "Offset is: 55 | Raw bytes for instruction 1: 1F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
+      "Offset is: 110 | Raw bytes for instruction 2: 0C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 40 00 00 00 03 C0 43 10\n",
+      "Offset is: 165 | Raw bytes for instruction 3: 6C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 40 00 00 00 03 C0 43 10\n",
+      "Offset is: 220 | Raw bytes for instruction 4: 4D 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10\n",
+      "Offset is: 275 | Raw bytes for instruction 5: 3F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
       "End of Instruction Table\n"
      ]
     }
    ],
    "source": [
-    "MAX_SIZE = 256\n",
-    "# for _ in range(step_instructions.shape[0] + 2): # + 2 to catch header and footer\n",
-    "for _ in range(MAX_SIZE):\n",
-    "    resp = Binary_Routine_Test.catch_response()\n",
-    "    print(resp)\n",
-    "    if \"End of\" in resp:\n",
-    "        break\n",
-    "    elif \"Cannot\" in resp:\n",
-    "        break"
+    "phase_sweep_test.read_table()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0 0x0\n",
+      "4096 0x1000\n",
+      "8192 0x2000\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(p0, hex(p0))\n",
+    "print(p1, hex(p1))\n",
+    "print(p2, hex(p2))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,19 +671,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
     "# conn.write(b'program\\n')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/testing/binary-tests.ipynb
+++ b/testing/binary-tests.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,67 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# def assert_OK():\n",
-    "#     resp = conn.readline().decode().strip()\n",
-    "#     assert resp == 'ok', 'Expected \"ok\", received \"%s\"' % resp\n",
-    "\n",
-    "# def allocate_sendb(instructions, channel):\n",
-    "#     ## tell setb how many instructions to expect \n",
-    "#     conn.write(b'setb %d %d\\n' % (channel, len(instructions)))\n",
-    "#     response = conn.readline().decode()\n",
-    "#     if not response.startswith('ready'):\n",
-    "#         response += ''.join([r.decode() for r in conn.readlines()])\n",
-    "#         raise Exception(f'setb command failed, response: {repr(response)}')\n",
-    "#     print(f'Got response: {response}')\n",
-    "\n",
-    "# def stop_sendb(instructions):\n",
-    "#     conn.write(b'set 4 %d\\n' % len(instructions))\n",
-    "#     assert_OK(), 'table not stopped correctly'\n",
-    "#     print('table finished')\n",
-    "\n",
-    "# # def write_sendb(instructions, channel):\n",
-    "\n",
-    "# def sendb(instructions: np.ndarray, channel: int = 0, multi_channel = False) -> str:\n",
-    "#     \"\"\"Sends a table of instructions to the sweeper to be read in binary mode `setb`.\n",
-    "\n",
-    "#     Parameters\n",
-    "#     ----------\n",
-    "#     instructions : np.ndarray \n",
-    "#         the table of instructions to be processed.\n",
-    "\n",
-    "#     channel : int  \n",
-    "#         instruction channel, defaults to 0.\n",
-    "\n",
-    "#     multi_channel : bool \n",
-    "#         bool option to send commands to more than one channel and handle channel mirroring, defaults to False.\n",
-    "\n",
-    "#     \"\"\"\n",
-    "\n",
-    "#     try:\n",
-    "\n",
-    "#         allocate_sendb(instructions, channel)\n",
-    "\n",
-    "#         conn.write(instructions.tobytes())\n",
-    "#         assert_OK(), 'table not written correctly'\n",
-    "#         print('table written')\n",
-    "        \n",
-    "#         # conn.write(b'set 4 %d\\n' % len(instructions))\n",
-    "#         # assert_OK(), 'table not stopped correctly'\n",
-    "#         # print('table finished')\n",
-    "\n",
-    "#         # stop_sendb(instructions)\n",
-    "\n",
-    "#     except Exception as e:\n",
-    "#         raise e\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,19 +221,9 @@
     "p2 = get_pow(phase = 180)\n",
     "p3 = get_pow(phase = 270)\n",
     "\n",
-    "t = 1\n",
+    "t = 2\n",
     "\n",
     "step_instructions = np.array([\n",
-    "                                # (f2, 1023, p1, t),\n",
-    "                                # (f2, 800, p1, t),\n",
-    "                                # (f2, 1023, p1, t),\n",
-    "                                # (f2, 200, p1, t),\n",
-    "                                # (f2, 800, p1, t),\n",
-    "                                # (f2, 1023, p1, t),\n",
-    "                                # (f2, 200, p1, t),\n",
-    "                                # (f2, 800, p1, t),\n",
-    "                                # (f2, 1023, p1, t),\n",
-    "                                # (f2, 800, p1, t)\n",
     "                                (f2, a1, p1, t),\n",
     "                                (f3, a2, p1, t),\n",
     "                                (f1, a1, p1, t),\n",
@@ -304,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +243,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -341,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +280,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -359,7 +289,7 @@
        "10"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -370,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -388,7 +318,7 @@
        "4096"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -399,7 +329,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0x33333333\n",
+      "0x3d70a3d7\n",
+      "0x3851eb85\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(hex(f1))\n",
+    "print(hex(f2))\n",
+    "print(hex(f3))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0x3ff\n",
+      "0x1f4\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(hex(1023))\n",
+    "print(hex(500))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -407,14 +377,10 @@
      "output_type": "stream",
      "text": [
       "Instruction Table Dump:\n",
-      "Instruction 0: 71135395 55045 4096 100668415\n",
-      "Instruction format: 04 3D 70 A3 | D7 05 | 10 00 | 06 00 13 FF\n",
-      "Instruction 1: 70799851 34053 4096 100667892\n",
-      "Instruction format: 04 38 51 EB | 85 05 | 10 00 | 06 00 11 F4\n",
-      "Instruction 2: 70464307 13061 4096 100668415\n",
-      "Instruction format: 04 33 33 33 | 33 05 | 10 00 | 06 00 13 FF\n",
-      "Instruction 3: 70799851 34053 4096 100668415\n",
-      "Instruction format: 04 38 51 EB | 85 05 | 10 00 | 06 00 13 FF\n",
+      "Offset is: 0 ||Raw bytes for instruction 0: 3F 00 F2 04 3D 70 A3 D7 05 10 00 06 00 13 FF\n",
+      "Offset is: 15 ||Raw bytes for instruction 1: 01 00 F2 04 38 51 EB 85 05 10 00 06 00 11 F4\n",
+      "Offset is: 30 ||Raw bytes for instruction 2: 05 00 F2 04 33 33 33 33 05 10 00 06 00 13 FF\n",
+      "Offset is: 45 ||Raw bytes for instruction 3: 01 00 F2 04 38 51 EB 85 05 10 00 06 00 13 FF\n",
       "End of Instruction Table\n"
      ]
     }
@@ -433,20 +399,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "# x = get_ftw(freq_out=120 * MHZ, freq_sys=125 * MHZ)\n",
-    "# len(str(x)) == len(str(4060403619)) # true\n",
-    "# x"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "Binary_Routine_Test.catch_response()"
    ]
@@ -467,7 +433,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +449,7 @@
     "\n",
     "d = 100\n",
     "r = 1\n",
-    "t = 1\n",
+    "t = 2\n",
     "\n",
     "freq_sweep_table = np.array([\n",
     "                            (f1, f3, d, r, t),\n",
@@ -502,9 +468,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sending commands to 1 channels\n",
+      "Got response: ready for 170 bytes\n",
+      "\n",
+      "table written to memory\n",
+      "table end command sent\n",
+      "table executed\n"
+     ]
+    }
+   ],
    "source": [
     "freq_sweep_test = Binary_Routines()\n",
     "# print(freq_sweep_test.catch_response())\n",
@@ -514,6 +493,62 @@
     "freq_sweep_test.table_to_memory(instructions=freq_sweep_table)\n",
     "freq_sweep_test.end_table(instructions=freq_sweep_table)\n",
     "freq_sweep_test.start_routine()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conn.write(b'readtable\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Instruction Table Dump:\n",
+      "Offset is: 0 ||Raw bytes for instruction 0: FF 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is: 30 ||Raw bytes for instruction 1: FF 00 F2 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 60 ||Raw bytes for instruction 2: 0F 00 F2 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 90 ||Raw bytes for instruction 3: 0F 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
+      "Offset is: 120 ||Raw bytes for instruction 4: 0F 00 F2 04 3D 70 A3 D7 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 150 ||Raw bytes for instruction 5: 0F 00 F2 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is: 180 ||Raw bytes for instruction 6: 0F 00 F2 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is: 210 ||Raw bytes for instruction 7: FF 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 240 ||Raw bytes for instruction 8: 0F 00 F2 04 38 51 EB 85 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is: 270 ||Raw bytes for instruction 9: 0F 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
+      "End of Instruction Table\n"
+     ]
+    }
+   ],
+   "source": [
+    "MAX_SIZE = 256\n",
+    "# for _ in range(step_instructions.shape[0] + 2): # + 2 to catch header and footer\n",
+    "for _ in range(MAX_SIZE):\n",
+    "    resp = Binary_Routine_Test.catch_response()\n",
+    "    print(resp)\n",
+    "    if \"End of\" in resp:\n",
+    "        break\n",
+    "    elif \"Cannot\" in resp:\n",
+    "        break"
    ]
   },
   {
@@ -532,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,9 +626,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sending commands to 2 channels\n",
+      "Got response: ready for 132 bytes\n",
+      "\n",
+      "table written to memory\n",
+      "table end command sent\n",
+      "table executed\n"
+     ]
+    }
+   ],
    "source": [
     "phase_sweep_test = Binary_Routines()\n",
     "phase_sweep_test.debug_on()\n",
@@ -611,24 +659,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# #### not always necessary, just if you want to move back to tests.ipynb\n",
-    "# conn.close()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -648,9 +679,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "conn.write(b'readtable\\n')\n",
     "# phase_sweep_test.assert_OK()"
@@ -658,16 +700,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Instruction Table Dump:\n",
+      "Offset is: 0 ||Raw bytes for instruction 0: 3F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10\n",
+      "Offset is: 55 ||Raw bytes for instruction 1: 1F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10\n",
+      "Offset is: 110 ||Raw bytes for instruction 2: 0C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10\n",
+      "Offset is: 165 ||Raw bytes for instruction 3: AC 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
+      "Offset is: 220 ||Raw bytes for instruction 4: 4D 00 12 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 40 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 40 00 00 00 03 C0 43 10\n",
+      "Offset is: 275 ||Raw bytes for instruction 5: BF 00 12 05 10 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
+      "End of Instruction Table\n"
+     ]
+    }
+   ],
    "source": [
-    "Binary_Routine_Test.catch_response()\n"
+    "MAX_SIZE = 256\n",
+    "# for _ in range(step_instructions.shape[0] + 2): # + 2 to catch header and footer\n",
+    "for _ in range(MAX_SIZE):\n",
+    "    resp = Binary_Routine_Test.catch_response()\n",
+    "    print(resp)\n",
+    "    if \"End of\" in resp:\n",
+    "        break\n",
+    "    elif \"Cannot\" in resp:\n",
+    "        break"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# #### not always necessary, just if you want to move back to tests.ipynb\n",
+    "# conn.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/testing/binary-tests.ipynb
+++ b/testing/binary-tests.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,6 +11,7 @@
     "import pyvisa \n",
     "import numpy as np\n",
     "from IPython.display import Image, display\n",
+    "import KeysightScope\n",
     "\n",
     "# You will have to change this to whatever COM port the pico is assigned when\n",
     "# you plug it in.\n",
@@ -33,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,61 +43,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
-    "class KeysightScope:\n",
-    "    \"\"\"\n",
-    "    Helper class using pyvisa for a USB connected Keysight Oscilloscope \n",
-    "    \"\"\"\n",
-    "    def __init__(self, \n",
-    "                 addr='USB?*::INSTR',\n",
-    "                 timeout=1, \n",
-    "                 termination='\\n'\n",
-    "                 ):\n",
-    "        rm = pyvisa.ResourceManager()\n",
-    "        devs = rm.list_resources(addr)\n",
-    "        assert len(devs), \"pyvisa didn't find any connected devices matching \" + addr\n",
-    "        self.dev = rm.open_resource(devs[0])\n",
-    "        self.dev.timeout = 15_000 * timeout\n",
-    "        self.dev.read_termination = termination\n",
-    "        self.idn = self.dev.query('*IDN?')\n",
-    "        self.read = self.dev.read\n",
-    "        self.write = self.dev.write\n",
-    "        self.query = self.dev.query\n",
-    "\n",
-    "    def _get_screenshot(self, verbose=False):\n",
-    "        if verbose == True:\n",
-    "            print('Acquiring screen image...')\n",
-    "        return(self.dev.query_binary_values(':DISPlay:DATA? PNG, COLor', datatype='s'))\n",
-    "\n",
-    "    def save_screenshot(self, filepath, verbose=False, inksaver=False):\n",
-    "        if verbose == True:\n",
-    "            print('Saving screen image...')\n",
-    "        result = self._get_screenshot()\n",
-    "\n",
-    "        # Keysight scope defaults to inksaving for image save\n",
-    "        if inksaver == True:\n",
-    "            self.dev.write(':HARDcopy:INKSaver 1')\n",
-    "        else: \n",
-    "            self.dev.write(':HARDcopy:INKSaver OFF')\n",
-    "\n",
-    "        with open(f'{filepath}', 'wb+') as ofile:\n",
-    "            ofile.write(bytes(result))\n",
-    "\n",
-    "    def set_time_delay(self, time):\n",
-    "        self.write(f':TIMebase:DELay {time}')\n",
-    "\n",
-    "    def set_time_scale(self, time):\n",
-    "        self.write(f':TIMebase:SCALe {time}')\n",
-    "\n",
-    "my_instrument = KeysightScope()"
+    "my_instrument = KeysightScope.KeysightScope()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,6 +76,7 @@
     "        self.mirror_channels = False\n",
     "        self.debug_run = True\n",
     "        self.MAX_SIZE = 256\n",
+    "        self.instructions = None\n",
     "\n",
     "    def catch_response(self):\n",
     "        resp = conn.readline().decode().strip()\n",
@@ -165,6 +122,7 @@
     "    def end_table(self, instructions: np.ndarray):\n",
     "        conn.write(b'set 4 %d\\n' % len(instructions))\n",
     "        self.assert_OK(), 'table not stopped correctly'\n",
+    "        self.instructions = instructions\n",
     "        if self.debug_run == True:\n",
     "            print('table end command sent')\n",
     "\n",
@@ -176,11 +134,10 @@
     "\n",
     "    def read_table(self, indices = None):\n",
     "        conn.write(b'readtable\\n')\n",
-    "        for _ in range(self.MAX_SIZE):\n",
+    "        for i in range(self.instructions.size + 2): # plus two to catch header and footer\n",
     "            resp = self.catch_response()\n",
+    "            if indices == None:\n",
     "\n",
-    "            ## No readability hint or end of response\n",
-    "            if indices == None or \"End\" in resp:\n",
     "                print(resp)\n",
     "            else:\n",
     "                line = resp.split(\":\")\n",
@@ -190,14 +147,13 @@
     "                line[-1] = str_of_bytes\n",
     "                print(''.join(line))\n",
     "\n",
-    "            ## termination conditions\n",
     "            if \"End of\" in resp:\n",
     "                break\n",
     "            elif \"Cannot\" in resp:\n",
     "                break\n",
     "            elif len(resp) == 0:\n",
     "                break\n",
-    "        # self.assert_OK, 'something went wrong reading table'\n",
+    "            \n",
     "\n",
     "    def get_memory_layout(self):\n",
     "        conn.write(b'getmode\\n')\n",
@@ -211,12 +167,12 @@
     "        print(memory_layout)\n",
     "        # self.assert_OK, 'something went wrong getting memory layout'\n",
     "        \n",
-    "Binary_Routine_Test = Binary_Routines()"
+    "binary_routine_test = Binary_Routines()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,14 +212,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt = np.dtype([('frequency', np.uint32), \n",
-    "               ('amplitude', np.uint16), \n",
-    "               ('phase', np.uint16), \n",
-    "               ('time', np.uint32)])\n",
+    "dt = np.dtype([('frequency', '<u4'), \n",
+    "               ('amplitude', '<u2'), \n",
+    "               ('phase', '<u2'), \n",
+    "               ('time', '<u4')])\n",
     "\n",
     "f1 = get_ftw(freq_out = 100 * MHZ)\n",
     "f2 = get_ftw(freq_out = 120 * MHZ)\n",
@@ -289,7 +245,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -325,63 +281,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Instruction Table Dump||||\n",
-      "Offset is 0 | Raw bytes for instruction 0| 7F 00 |F2 04 3D |70 A3| D7 05 10 00 06 00 13 FF\n",
-      "Offset is 15 | Raw bytes for instruction 1| 01 00 |F2 04 38 |51 EB| 85 05 10 00 06 00 11 F4\n",
-      "Offset is 30 | Raw bytes for instruction 2| 05 00 |F2 04 33 |33 33| 33 05 10 00 06 00 13 FF\n",
-      "Offset is 45 | Raw bytes for instruction 3| 01 00 |F2 04 38 |51 EB| 85 05 10 00 06 00 13 FF\n",
+      "Instruction Table Dump:\n",
+      "Offset is: 0 | Raw bytes for instruction 0: 4D 00 12 04 3D 70 A3 D7 05 10 00 06 00 13 FF Timing: _1E2\n",
+      "Offset is: 15 | Raw bytes for instruction 1: 01 00 12 04 38 51 EB 85 05 10 00 06 00 11 F4 Timing: _1EA\n",
+      "Offset is: 30 | Raw bytes for instruction 2: 05 00 12 04 33 33 33 33 05 10 00 06 00 13 FF Timing: _1EA\n",
+      "Offset is: 45 | Raw bytes for instruction 3: 01 00 12 04 38 51 EB 85 05 10 00 06 00 13 FF Timing: _1EA\n",
       "End of Instruction Table\n"
      ]
     }
    ],
    "source": [
-    "single_step_test.read_table(indices=[0, 4, 9, 12])"
+    "single_step_test.read_table()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "mode Mode 0 - Single Steps\n",
-      "Active channels: 1\n",
-      "datatypes = np.dtype([('frequency', np.uint32), ('amplitude', np.uint16), ('phase', np.uint16), ('time', np.uint32)])\n"
+      "0\n"
      ]
     }
    ],
    "source": [
-    "single_step_test.get_memory_layout()"
+    "conn.write(b'status\\n')\n",
+    "print(single_step_test.catch_response())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "''"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4\n"
+     ]
     }
    ],
    "source": [
-    "single_step_test.catch_response()"
+    "conn.write(b'numtriggers\\n')\n",
+    "print(single_step_test.catch_response())"
    ]
   },
   {
@@ -400,15 +353,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt = np.dtype([('start frequency', np.uint32), \n",
-    "               ('stop frequency', np.uint32), \n",
-    "               ('delta', np.uint32), \n",
-    "               ('rate', np.uint8), \n",
-    "               ('time', np.uint32)])\n",
+    "dt = np.dtype([('start frequency', \"<u4\"), \n",
+    "               ('stop frequency', \"<u4\"), \n",
+    "               ('delta', \"<u4\"), \n",
+    "               ('rate', \"<u1\"), \n",
+    "               ('time', \"<u4\")])\n",
     "\n",
     "f1 = get_ftw(freq_out = 100 * MHZ)\n",
     "f2 = get_ftw(freq_out = 120 * MHZ)\n",
@@ -435,7 +388,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [
     {
@@ -462,49 +415,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Instruction Table Dump||||\n",
-      "Offset is 0 | Raw bytes for instruction 0| FF 00 F2 04 |33 33 33 33| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is 30 | Raw bytes for instruction 1| FF 00 F2 04 |38 51 EB 85| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is 60 | Raw bytes for instruction 2| 0F 00 F2 04 |33 33 33 33| 07 01 |01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is 90 | Raw bytes for instruction 3| 0F 00 F2 04 |33 33 33 33| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
-      "Offset is 120 | Raw bytes for instruction 4| 0F 00 F2 04 |3D 70 A3 D7| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is 150 | Raw bytes for instruction 5| 0F 00 F2 04 |38 51 EB 85| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is 180 | Raw bytes for instruction 6| 0F 00 F2 04 |33 33 33 33| 07 01 |01 08 FF FF FF FF 09 00 00 00 64 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is 210 | Raw bytes for instruction 7| FF 00 F2 04 |33 33 33 33| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is 240 | Raw bytes for instruction 8| 0F 00 F2 04 |38 51 EB 85| 07 01 |01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is 270 | Raw bytes for instruction 9| 0F 00 F2 04 |33 33 33 33| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
+      "Instruction Table Dump:\n",
+      "Offset is: 0 | Raw bytes for instruction 0: CD 00 12 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10 Timing: _3D6\n",
+      "Offset is: 30 | Raw bytes for instruction 1: 8D 00 12 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10 Timing: _3DE\n",
+      "Offset is: 60 | Raw bytes for instruction 2: 08 00 12 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10 Timing: _3DE\n",
+      "Offset is: 90 | Raw bytes for instruction 3: 09 00 12 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10 Timing: _3DE\n",
+      "Offset is: 120 | Raw bytes for instruction 4: 09 00 12 04 3D 70 A3 D7 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10 Timing: _3DE\n",
+      "Offset is: 150 | Raw bytes for instruction 5: 7F 00 12 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10 Timing: _3DE\n",
+      "Offset is: 180 | Raw bytes for instruction 6: 09 00 12 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 38 51 EB 85 03 80 43 10 Timing: _3DE\n",
+      "Offset is: 210 | Raw bytes for instruction 7: 89 00 12 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10 Timing: _3DE\n",
+      "Offset is: 240 | Raw bytes for instruction 8: 09 00 12 04 38 51 EB 85 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10 Timing: _3DE\n",
+      "Offset is: 270 | Raw bytes for instruction 9: 09 00 12 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10 Timing: _3DE\n",
       "End of Instruction Table\n"
      ]
     }
    ],
    "source": [
-    "freq_sweep_test.read_table(indices=[0, 7, 13, 17])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "mode Mode 2 - Frequency Sweeps\n",
-      "Active channels: 1\n",
-      "datatypes = np.dtype([('start frequency', np.uint32), ('stop frequency', np.uint32), ('delta', np.uint32), ('rate', np.uint8),\n"
-     ]
-    }
-   ],
-   "source": [
-    "freq_sweep_test.get_memory_layout()"
+    "freq_sweep_test.read_table()"
    ]
   },
   {
@@ -523,30 +457,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
-    "for i in range(4):\n",
-    "    conn.write(b'setfreq %d 100000000\\n' % i)\n",
-    "    Binary_Routine_Test.catch_response()\n",
-    "\n",
-    "    conn.write(b'setphase %d 0\\n' % i)\n",
-    "    Binary_Routine_Test.catch_response()\n",
-    "\n",
-    "    conn.write(b'setamp %d 1023\\n' % i)\n",
-    "    Binary_Routine_Test.catch_response()\n",
-    "\n",
-    "dt = np.dtype([('start phase0', np.uint16), \n",
-    "               ('stop phase0', np.uint16), \n",
-    "               ('delta0', np.uint16), \n",
-    "               ('rate0', np.uint8),\n",
-    "               ('time0', np.uint32),\n",
-    "               ('start phase1', np.uint16), \n",
-    "               ('stop phase1', np.uint16), \n",
-    "               ('delta1', np.uint16), \n",
-    "               ('rate1', np.uint8), \n",
-    "               ('time1', np.uint32)])\n",
+    "dt = np.dtype([('start phase0', \"<u2\"), \n",
+    "               ('stop phase0', \"<u2\"), \n",
+    "               ('delta0', \"<u2\"), \n",
+    "               ('rate0', \"<u1\"),\n",
+    "               ('time0', \"<u4\"),\n",
+    "               ('start phase1', \"<u2\"), \n",
+    "               ('stop phase1', \"<u2\"), \n",
+    "               ('delta1', \"<u2\"), \n",
+    "               ('rate1', \"<u1\"), \n",
+    "               ('time1', \"<u4\")])\n",
     "\n",
     "p0 = get_pow(phase = 0)\n",
     "p1 = get_pow(phase = 90)\n",
@@ -556,23 +480,23 @@
     "\n",
     "d = 1\n",
     "r = 1\n",
-    "t = 2\n",
+    "t = 200\n",
     "\n",
     "\n",
     "phase_sweep_instructions = np.array([\n",
     "                                    (0, 0, d, r, t, p0, p2, d, r, t),\n",
     "                                    (0, 0, d, r, t, p2, p1, d, r, t),\n",
     "                                    (0, 0, d, r, t, p1, p0, d, r, t),\n",
-    "                                    # (0, 0, d, r, t, p0, p1, d, r, t),\n",
-    "                                    # (0, 0, d, r, t, p1, p2, d, r, t),\n",
-    "                                    # (0, 0, d, r, t, p2, p0, d, r, t),\n",
+    "                                    (0, 0, d, r, t, p0, p1, d, r, t),\n",
+    "                                    (0, 0, d, r, t, p1, p2, d, r, t),\n",
+    "                                    (0, 0, d, r, t, p2, p0, d, r, t),\n",
     "                                 ]\n",
     "                                 , dtype = dt)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
@@ -581,18 +505,18 @@
        "''"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 57,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "Binary_Routine_Test.catch_response()"
+    "binary_routine_test.catch_response()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
@@ -600,7 +524,7 @@
      "output_type": "stream",
      "text": [
       "sending commands to 2 channels\n",
-      "Got response: ready for 66 bytes\n",
+      "Got response: ready for 132 bytes\n",
       "\n",
       "table written to memory\n",
       "table end command sent\n",
@@ -613,6 +537,16 @@
     "phase_sweep_test.debug_off()\n",
     "phase_sweep_test.set_mode(sweep_mode=3, timing_mode=1, num_channels=2)\n",
     "\n",
+    "for i in range(4):\n",
+    "    conn.write(b'setfreq %d 100000000\\n' % i)\n",
+    "    binary_routine_test.catch_response()\n",
+    "\n",
+    "    conn.write(b'setphase %d 0\\n' % i)\n",
+    "    binary_routine_test.catch_response()\n",
+    "\n",
+    "    conn.write(b'setamp %d 1\\n' % i)\n",
+    "    binary_routine_test.catch_response()\n",
+    "\n",
     "phase_sweep_test.allocate(start_address=0, instructions=phase_sweep_instructions)\n",
     "phase_sweep_test.table_to_memory(instructions=phase_sweep_instructions)\n",
     "\n",
@@ -622,26 +556,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "mode Mode 3 - Phase Sweeps\n",
-      "Active channels: 2\n",
-      "datatypes = np.dtype([('start phase', np.uint16), ('stop phase', np.uint16), ('delta', np.uint16), ('rate', np.uint8), ('time',\n"
-     ]
-    }
-   ],
-   "source": [
-    "phase_sweep_test.get_memory_layout()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -649,9 +564,12 @@
      "output_type": "stream",
      "text": [
       "Instruction Table Dump:\n",
-      "Offset is: 0 | Raw bytes for instruction 0: 7F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10\n",
-      "Offset is: 55 | Raw bytes for instruction 1: 1F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
-      "Offset is: 110 | Raw bytes for instruction 2: 0C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 40 00 00 00 03 C0 43 10\n",
+      "Offset is: 0 | Raw bytes for instruction 0: 4D 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10 Timing: _5CA\n",
+      "Offset is: 55 | Raw bytes for instruction 1: 1F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10 Timing: _5D2\n",
+      "Offset is: 110 | Raw bytes for instruction 2: 0C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 40 00 00 00 03 C0 43 10 Timing: _5D2\n",
+      "Offset is: 165 | Raw bytes for instruction 3: 6C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 40 00 00 00 03 C0 43 10 Timing: _5D2\n",
+      "Offset is: 220 | Raw bytes for instruction 4: 4D 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10 Timing: _5D2\n",
+      "Offset is: 275 | Raw bytes for instruction 5: 3F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10 Timing: _5D2\n",
       "End of Instruction Table\n"
      ]
     }
@@ -662,91 +580,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0 0x0\n",
-      "4096 0x1000\n",
-      "8192 0x2000\n"
+      "0\n"
      ]
     }
    ],
    "source": [
-    "print(p0, hex(p0))\n",
-    "print(p1, hex(p1))\n",
-    "print(p2, hex(p2))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# #### not always necessary, just if you want to move back to tests.ipynb\n",
-    "# conn.close()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# conn.write(b'program\\n')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# for i in range(4):\n",
-    "#     conn.write(b'setfreq %d 100000000\\n' % i)\n",
-    "#     Binary_Routine_Test.catch_response()\n",
-    "\n",
-    "#     conn.write(b'setphase %d 0\\n' % i)\n",
-    "#     Binary_Routine_Test.catch_response()\n",
-    "\n",
-    "#     conn.write(b'setamp %d 1023\\n' % i)\n",
-    "#     Binary_Routine_Test.catch_response()\n",
-    "\n",
-    "# dt = np.dtype([('start amp0', np.uint16), \n",
-    "#                ('stop amp0', np.uint16), \n",
-    "#                ('delta0', np.uint16), \n",
-    "#                ('rate0', np.uint8),\n",
-    "#                ('time0', np.uint32),\n",
-    "#                ('start amp1', np.uint16), \n",
-    "#                ('stop amp1', np.uint16), \n",
-    "#                ('delta1', np.uint16), \n",
-    "#                ('rate1', np.uint8), \n",
-    "#                ('time1', np.uint32)])\n",
-    "\n",
-    "# p0 = get_pow(phase = 0)\n",
-    "# p1 = get_pow(phase = 90)\n",
-    "# p2 = get_pow(phase = 180)\n",
-    "# p3 = get_pow(phase = 270)\n",
-    "# p4 = get_pow(phase = 360)\n",
-    "\n",
-    "# d = 1\n",
-    "# r = 1\n",
-    "# t = 2\n",
-    "\n",
-    "\n",
-    "# phase_sweep_instructions = np.array([\n",
-    "#                                     (0, 0, d, r, t, p0, p2, d, r, t),\n",
-    "#                                     (0, 0, d, r, t, p2, p1, d, r, t),\n",
-    "#                                     (0, 0, d, r, t, p1, p0, d, r, t),\n",
-    "#                                     (0, 0, d, r, t, p0, p1, d, r, t),\n",
-    "#                                     (0, 0, d, r, t, p1, p2, d, r, t),\n",
-    "#                                     (0, 0, d, r, t, p2, p0, d, r, t),\n",
-    "#                                  ]\n",
-    "#                                  , dtype = dt)"
+    "conn.write(b'status\\n')\n",
+    "print(binary_routine_test.catch_response())"
    ]
   }
  ],

--- a/testing/binary-tests.ipynb
+++ b/testing/binary-tests.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,13 +96,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
     "class Binary_Routines():\n",
     "    def __init__(self):\n",
     "        self.mirror_channels = False\n",
+    "        self.debug_run = True\n",
     "\n",
     "    def catch_response(self):\n",
     "        resp = conn.readline().decode().strip()\n",
@@ -123,7 +124,8 @@
     "        self.assert_OK()\n",
     "        conn.write(b'setchannels %d\\n' % num_channels)\n",
     "        self.assert_OK()\n",
-    "        print('sending commands to %d channels' % num_channels)\n",
+    "        if self.debug_run == True:\n",
+    "            print('sending commands to %d channels' % num_channels)\n",
     "\n",
     "    def allocate(self, start_address: int, instructions: np.ndarray):\n",
     "        conn.write(b'setb %d %d\\n' % (start_address, len(instructions)))\n",
@@ -131,29 +133,33 @@
     "        if not response.startswith('ready'):\n",
     "            response += ''.join([r.decode() for r in conn.readlines()])\n",
     "            raise Exception(f'setb command failed, response: {repr(response)}')\n",
-    "        print(f'Got response: {response}')\n",
+    "        if self.debug_run == True:\n",
+    "            print(f'Got response: {response}')\n",
     "\n",
     "    def table_to_memory(self, instructions: np.ndarray):\n",
     "        conn.write(instructions.tobytes())\n",
     "        self.assert_OK(), 'table not written correctly'\n",
-    "        print('table written to memory')\n",
+    "        if self.debug_run == True:\n",
+    "            print('table written to memory')\n",
     "\n",
     "    def end_table(self, instructions: np.ndarray):\n",
     "        conn.write(b'set 4 %d\\n' % len(instructions))\n",
     "        self.assert_OK(), 'table not stopped correctly'\n",
-    "        print('table end command sent')\n",
+    "        if self.debug_run == True:\n",
+    "            print('table end command sent')\n",
     "\n",
     "    def start_routine(self):\n",
     "        conn.write(b'start\\n')\n",
     "        self.assert_OK(), 'table did not start'\n",
-    "        print('table executed')\n",
+    "        if self.debug_run == True:\n",
+    "            print('table executed')\n",
     "\n",
     "Binary_Routine_Test = Binary_Routines()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,17 +259,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# dt = np.dtype([('frequency', np.uint32), ('amplitude', np.uint16), ('phase', np.uint16), ('time', np.uint32)])\n",
-    "dt = np.dtype([\n",
-    "    ('frequency', '>u4'),  # Big-endian uint32\n",
-    "    ('amplitude', '>u2'),  # Big-endian uint16\n",
-    "    ('phase', '>u2'),      # Big-endian uint16\n",
-    "    ('time', '>u4')        # Big-endian uint32\n",
-    "])\n",
+    "dt = np.dtype([('frequency', np.uint32), ('amplitude', np.uint16), ('phase', np.uint16), ('time', np.uint32)])\n",
+    "# dt = np.dtype([\n",
+    "#     ('frequency', '>u4'),  # Big-endian uint32\n",
+    "#     ('amplitude', '>u2'),  # Big-endian uint16\n",
+    "#     ('phase', '>u2'),      # Big-endian uint16\n",
+    "#     ('time', '>u4')        # Big-endian uint32\n",
+    "# ])\n",
     "f1 = get_ftw(freq_out = 100 * MHZ)\n",
     "f2 = get_ftw(freq_out = 120 * MHZ)\n",
     "f3 = get_ftw(freq_out = 110 * MHZ)\n",
@@ -298,26 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "b'3d70a3d703ff1000000000013851eb8501f41000000000013333333303ff1000000000013851eb8503ff100000000001'\n"
-     ]
-    }
-   ],
-   "source": [
-    "step_bytes = step_instructions.tobytes()\n",
-    "import binascii\n",
-    "print(binascii.hexlify(step_bytes))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -354,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -372,7 +359,7 @@
        "10"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -383,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -392,7 +379,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4096"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "p1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -400,18 +407,14 @@
      "output_type": "stream",
      "text": [
       "Instruction Table Dump:\n",
-      "Raw bytes for instruction 0: F2 04 D7 A3 70 3D 05 00 10 06 00 13 03 01 00\n",
-      "Instruction format: F2 04 D7 A3 | 70 3D | 05 00 | 10 06 00 13\n",
-      "Instruction 0: 4060403619 28733 1280 268828691\n",
-      "Raw bytes for instruction 1: F2 04 85 EB 51 38 05 00 10 06 00 10 01 01 00\n",
-      "Instruction format: F2 04 85 EB | 51 38 | 05 00 | 10 06 00 10\n",
-      "Instruction 1: 4060382699 20792 1280 268828688\n",
-      "Raw bytes for instruction 2: F2 04 33 33 33 33 05 00 10 06 00 13 03 01 00\n",
-      "Instruction format: F2 04 33 33 | 33 33 | 05 00 | 10 06 00 13\n",
-      "Instruction 2: 4060361523 13107 1280 268828691\n",
-      "Raw bytes for instruction 3: F2 04 85 EB 51 38 05 00 10 06 00 13 03 00 00\n",
-      "Instruction format: F2 04 85 EB | 51 38 | 05 00 | 10 06 00 13\n",
-      "Instruction 3: 4060382699 20792 1280 268828691\n",
+      "Instruction 0: 71135395 55045 4096 100668415\n",
+      "Instruction format: 04 3D 70 A3 | D7 05 | 10 00 | 06 00 13 FF\n",
+      "Instruction 1: 70799851 34053 4096 100667892\n",
+      "Instruction format: 04 38 51 EB | 85 05 | 10 00 | 06 00 11 F4\n",
+      "Instruction 2: 70464307 13061 4096 100668415\n",
+      "Instruction format: 04 33 33 33 | 33 05 | 10 00 | 06 00 13 FF\n",
+      "Instruction 3: 70799851 34053 4096 100668415\n",
+      "Instruction format: 04 38 51 EB | 85 05 | 10 00 | 06 00 13 FF\n",
       "End of Instruction Table\n"
      ]
     }
@@ -432,22 +435,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "4123168604"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "x = get_ftw(freq_out=120 * MHZ, freq_sys=125 * MHZ)\n",
-    "len(str(x)) == len(str(4060403619)) # true\n",
-    "x"
+    "# x = get_ftw(freq_out=120 * MHZ, freq_sys=125 * MHZ)\n",
+    "# len(str(x)) == len(str(4060403619)) # true\n",
+    "# x"
    ]
   },
   {

--- a/testing/binary-tests.ipynb
+++ b/testing/binary-tests.ipynb
@@ -100,6 +100,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "def insert_string(original_string, string_to_insert, index):\n",
+    "\n",
+    "    return original_string[:index] + string_to_insert + original_string[index:]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "class Binary_Routines():\n",
     "    \"\"\"\n",
     "    Class handler for `setb` command to send binary tables to the dds-sweeper\n",
@@ -163,11 +174,23 @@
     "        if self.debug_run == True:\n",
     "            print('table executed')\n",
     "\n",
-    "    def read_table(self):\n",
+    "    def read_table(self, indices = None):\n",
     "        conn.write(b'readtable\\n')\n",
     "        for _ in range(self.MAX_SIZE):\n",
     "            resp = self.catch_response()\n",
-    "            print(resp)\n",
+    "\n",
+    "            ## No readability hint or end of response\n",
+    "            if indices == None or \"End\" in resp:\n",
+    "                print(resp)\n",
+    "            else:\n",
+    "                line = resp.split(\":\")\n",
+    "                str_of_bytes = line[-1]\n",
+    "                for ind in indices:\n",
+    "                    str_of_bytes = insert_string(str_of_bytes, \"|\", ind * 2)\n",
+    "                line[-1] = str_of_bytes\n",
+    "                print(''.join(line))\n",
+    "\n",
+    "            ## termination conditions\n",
     "            if \"End of\" in resp:\n",
     "                break\n",
     "            elif \"Cannot\" in resp:\n",
@@ -187,14 +210,13 @@
     "        print(channels)\n",
     "        print(memory_layout)\n",
     "        # self.assert_OK, 'something went wrong getting memory layout'\n",
-    "\n",
     "        \n",
     "Binary_Routine_Test = Binary_Routines()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,12 +284,12 @@
     "                                (f1, a1, p1, t),\n",
     "                                (f3, a1, p1, t),\n",
     "                                 ]\n",
-    "                                 , dtype = dt)\n"
+    "                                 , dtype = dt)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +298,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -303,29 +325,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Instruction Table Dump:\n",
-      "Offset is: 0 | Raw bytes for instruction 0: 7F 00 F2 04 3D 70 A3 D7 05 10 00 06 00 13 FF\n",
-      "Offset is: 15 | Raw bytes for instruction 1: 01 00 F2 04 38 51 EB 85 05 10 00 06 00 11 F4\n",
-      "Offset is: 30 | Raw bytes for instruction 2: 05 00 F2 04 33 33 33 33 05 10 00 06 00 13 FF\n",
-      "Offset is: 45 | Raw bytes for instruction 3: 01 00 F2 04 38 51 EB 85 05 10 00 06 00 13 FF\n",
+      "Instruction Table Dump||||\n",
+      "Offset is 0 | Raw bytes for instruction 0| 7F 00 |F2 04 3D |70 A3| D7 05 10 00 06 00 13 FF\n",
+      "Offset is 15 | Raw bytes for instruction 1| 01 00 |F2 04 38 |51 EB| 85 05 10 00 06 00 11 F4\n",
+      "Offset is 30 | Raw bytes for instruction 2| 05 00 |F2 04 33 |33 33| 33 05 10 00 06 00 13 FF\n",
+      "Offset is 45 | Raw bytes for instruction 3| 01 00 |F2 04 38 |51 EB| 85 05 10 00 06 00 13 FF\n",
       "End of Instruction Table\n"
      ]
     }
    ],
    "source": [
-    "single_step_test.read_table()"
+    "single_step_test.read_table(indices=[0, 4, 9, 12])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -344,7 +366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -353,7 +375,7 @@
        "''"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -378,7 +400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,12 +430,12 @@
     "                            (f2, f3, d, r, t),\n",
     "                            (f1, f1, d, r, t),\n",
     "                                 ]\n",
-    "                                 , dtype = dt)\n"
+    "                                 , dtype = dt)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -440,35 +462,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Instruction Table Dump:\n",
-      "Offset is: 0 | Raw bytes for instruction 0: FF 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is: 30 | Raw bytes for instruction 1: FF 00 F2 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 60 | Raw bytes for instruction 2: 0F 00 F2 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 90 | Raw bytes for instruction 3: 0F 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
-      "Offset is: 120 | Raw bytes for instruction 4: 0F 00 F2 04 3D 70 A3 D7 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 150 | Raw bytes for instruction 5: 0F 00 F2 04 38 51 EB 85 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is: 180 | Raw bytes for instruction 6: 0F 00 F2 04 33 33 33 33 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 38 51 EB 85 03 80 43 10\n",
-      "Offset is: 210 | Raw bytes for instruction 7: FF 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 240 | Raw bytes for instruction 8: 0F 00 F2 04 38 51 EB 85 07 01 01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
-      "Offset is: 270 | Raw bytes for instruction 9: 0F 00 F2 04 33 33 33 33 07 01 01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
+      "Instruction Table Dump||||\n",
+      "Offset is 0 | Raw bytes for instruction 0| FF 00 F2 04 |33 33 33 33| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is 30 | Raw bytes for instruction 1| FF 00 F2 04 |38 51 EB 85| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is 60 | Raw bytes for instruction 2| 0F 00 F2 04 |33 33 33 33| 07 01 |01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is 90 | Raw bytes for instruction 3| 0F 00 F2 04 |33 33 33 33| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
+      "Offset is 120 | Raw bytes for instruction 4| 0F 00 F2 04 |3D 70 A3 D7| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is 150 | Raw bytes for instruction 5| 0F 00 F2 04 |38 51 EB 85| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is 180 | Raw bytes for instruction 6| 0F 00 F2 04 |33 33 33 33| 07 01 |01 08 FF FF FF FF 09 00 00 00 64 0A 38 51 EB 85 03 80 43 10\n",
+      "Offset is 210 | Raw bytes for instruction 7| FF 00 F2 04 |33 33 33 33| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is 240 | Raw bytes for instruction 8| 0F 00 F2 04 |38 51 EB 85| 07 01 |01 08 FF FF FF FF 09 00 00 00 64 0A 3D 70 A3 D7 03 80 43 10\n",
+      "Offset is 270 | Raw bytes for instruction 9| 0F 00 F2 04 |33 33 33 33| 07 01 |01 08 00 00 00 64 09 00 00 00 00 0A 33 33 33 33 03 80 43 10\n",
       "End of Instruction Table\n"
      ]
     }
    ],
    "source": [
-    "freq_sweep_test.read_table()"
+    "freq_sweep_test.read_table(indices=[0, 7, 13, 17])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -501,7 +523,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,6 +532,9 @@
     "    Binary_Routine_Test.catch_response()\n",
     "\n",
     "    conn.write(b'setphase %d 0\\n' % i)\n",
+    "    Binary_Routine_Test.catch_response()\n",
+    "\n",
+    "    conn.write(b'setamp %d 1023\\n' % i)\n",
     "    Binary_Routine_Test.catch_response()\n",
     "\n",
     "dt = np.dtype([('start phase0', np.uint16), \n",
@@ -538,16 +563,16 @@
     "                                    (0, 0, d, r, t, p0, p2, d, r, t),\n",
     "                                    (0, 0, d, r, t, p2, p1, d, r, t),\n",
     "                                    (0, 0, d, r, t, p1, p0, d, r, t),\n",
-    "                                    (0, 0, d, r, t, p0, p1, d, r, t),\n",
-    "                                    (0, 0, d, r, t, p1, p2, d, r, t),\n",
-    "                                    (0, 0, d, r, t, p2, p0, d, r, t),\n",
+    "                                    # (0, 0, d, r, t, p0, p1, d, r, t),\n",
+    "                                    # (0, 0, d, r, t, p1, p2, d, r, t),\n",
+    "                                    # (0, 0, d, r, t, p2, p0, d, r, t),\n",
     "                                 ]\n",
     "                                 , dtype = dt)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -556,7 +581,7 @@
        "''"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -567,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -575,7 +600,7 @@
      "output_type": "stream",
      "text": [
       "sending commands to 2 channels\n",
-      "Got response: ready for 132 bytes\n",
+      "Got response: ready for 66 bytes\n",
       "\n",
       "table written to memory\n",
       "table end command sent\n",
@@ -597,7 +622,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -616,7 +641,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -627,9 +652,6 @@
       "Offset is: 0 | Raw bytes for instruction 0: 7F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10\n",
       "Offset is: 55 | Raw bytes for instruction 1: 1F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
       "Offset is: 110 | Raw bytes for instruction 2: 0C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 40 00 00 00 03 C0 43 10\n",
-      "Offset is: 165 | Raw bytes for instruction 3: 6C 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 40 00 00 00 03 C0 43 10\n",
-      "Offset is: 220 | Raw bytes for instruction 4: 4D 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 10 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 80 00 00 00 03 C0 43 10\n",
-      "Offset is: 275 | Raw bytes for instruction 5: 3F 00 12 05 00 00 07 01 01 08 00 04 00 00 09 00 00 00 00 0A 00 00 00 00 03 C0 43 10 00 22 05 00 00 07 01 01 08 FF FF FF FF 09 00 04 00 00 0A 80 00 00 00 03 C0 43 10\n",
       "End of Instruction Table\n"
      ]
     }
@@ -640,7 +662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -661,7 +683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,11 +693,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
     "# conn.write(b'program\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for i in range(4):\n",
+    "#     conn.write(b'setfreq %d 100000000\\n' % i)\n",
+    "#     Binary_Routine_Test.catch_response()\n",
+    "\n",
+    "#     conn.write(b'setphase %d 0\\n' % i)\n",
+    "#     Binary_Routine_Test.catch_response()\n",
+    "\n",
+    "#     conn.write(b'setamp %d 1023\\n' % i)\n",
+    "#     Binary_Routine_Test.catch_response()\n",
+    "\n",
+    "# dt = np.dtype([('start amp0', np.uint16), \n",
+    "#                ('stop amp0', np.uint16), \n",
+    "#                ('delta0', np.uint16), \n",
+    "#                ('rate0', np.uint8),\n",
+    "#                ('time0', np.uint32),\n",
+    "#                ('start amp1', np.uint16), \n",
+    "#                ('stop amp1', np.uint16), \n",
+    "#                ('delta1', np.uint16), \n",
+    "#                ('rate1', np.uint8), \n",
+    "#                ('time1', np.uint32)])\n",
+    "\n",
+    "# p0 = get_pow(phase = 0)\n",
+    "# p1 = get_pow(phase = 90)\n",
+    "# p2 = get_pow(phase = 180)\n",
+    "# p3 = get_pow(phase = 270)\n",
+    "# p4 = get_pow(phase = 360)\n",
+    "\n",
+    "# d = 1\n",
+    "# r = 1\n",
+    "# t = 2\n",
+    "\n",
+    "\n",
+    "# phase_sweep_instructions = np.array([\n",
+    "#                                     (0, 0, d, r, t, p0, p2, d, r, t),\n",
+    "#                                     (0, 0, d, r, t, p2, p1, d, r, t),\n",
+    "#                                     (0, 0, d, r, t, p1, p0, d, r, t),\n",
+    "#                                     (0, 0, d, r, t, p0, p1, d, r, t),\n",
+    "#                                     (0, 0, d, r, t, p1, p2, d, r, t),\n",
+    "#                                     (0, 0, d, r, t, p2, p0, d, r, t),\n",
+    "#                                  ]\n",
+    "#                                  , dtype = dt)"
    ]
   }
  ],

--- a/testing/binary-tests.ipynb
+++ b/testing/binary-tests.ipynb
@@ -37,6 +37,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# conn.write(b'program\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "class KeysightScope:\n",
     "    \"\"\"\n",
     "    Helper class using pyvisa for a USB connected Keysight Oscilloscope \n",
@@ -87,13 +96,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
     "class Binary_Routines():\n",
     "    def __init__(self):\n",
     "        self.mirror_channels = False\n",
+    "\n",
+    "    def catch_response(self):\n",
+    "        resp = conn.readline().decode().strip()\n",
+    "        return resp\n",
     "\n",
     "    def assert_OK(self):\n",
     "        resp = conn.readline().decode().strip()\n",
@@ -140,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,15 +253,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt = np.dtype([('frequency', np.uint32), ('amplitude', np.uint16), ('phase', np.uint16), ('time', np.uint32)])\n",
-    "\n",
+    "# dt = np.dtype([('frequency', np.uint32), ('amplitude', np.uint16), ('phase', np.uint16), ('time', np.uint32)])\n",
+    "dt = np.dtype([\n",
+    "    ('frequency', '>u4'),  # Big-endian uint32\n",
+    "    ('amplitude', '>u2'),  # Big-endian uint16\n",
+    "    ('phase', '>u2'),      # Big-endian uint16\n",
+    "    ('time', '>u4')        # Big-endian uint32\n",
+    "])\n",
     "f1 = get_ftw(freq_out = 100 * MHZ)\n",
     "f2 = get_ftw(freq_out = 120 * MHZ)\n",
     "f3 = get_ftw(freq_out = 110 * MHZ)\n",
+    "\n",
+    "a1 = 1023\n",
+    "a2 = 500\n",
     "\n",
     "p1 = get_pow(phase = 90)\n",
     "p2 = get_pow(phase = 180)\n",
@@ -257,27 +278,22 @@
     "t = 1\n",
     "\n",
     "step_instructions = np.array([\n",
-    "                                (f2, 1023, p1, t),\n",
-    "                                (f2, 800, p1, t),\n",
-    "                                (f2, 1023, p1, t),\n",
-    "                                (f2, 200, p1, t),\n",
-    "                                (f2, 800, p1, t),\n",
-    "                                (f2, 1023, p1, t),\n",
-    "                                (f2, 200, p1, t),\n",
-    "                                (f2, 800, p1, t),\n",
-    "                                (f2, 1023, p1, t),\n",
-    "                                (f2, 800, p1, t)\n",
+    "                                # (f2, 1023, p1, t),\n",
+    "                                # (f2, 800, p1, t),\n",
+    "                                # (f2, 1023, p1, t),\n",
+    "                                # (f2, 200, p1, t),\n",
+    "                                # (f2, 800, p1, t),\n",
+    "                                # (f2, 1023, p1, t),\n",
+    "                                # (f2, 200, p1, t),\n",
+    "                                # (f2, 800, p1, t),\n",
+    "                                # (f2, 1023, p1, t),\n",
+    "                                # (f2, 800, p1, t)\n",
+    "                                (f2, a1, p1, t),\n",
+    "                                (f3, a2, p1, t),\n",
+    "                                (f1, a1, p1, t),\n",
+    "                                (f3, a1, p1, t),\n",
     "                                 ]\n",
     "                                 , dtype = dt)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "single_step_test = Binary_Routines()"
    ]
   },
   {
@@ -289,8 +305,36 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "b'3d70a3d703ff1000000000013851eb8501f41000000000013333333303ff1000000000013851eb8503ff100000000001'\n"
+     ]
+    }
+   ],
+   "source": [
+    "step_bytes = step_instructions.tobytes()\n",
+    "import binascii\n",
+    "print(binascii.hexlify(step_bytes))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_step_test = Binary_Routines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "sending commands to 1 channels\n",
-      "Got response: ready for 120 bytes\n",
+      "Got response: ready for 48 bytes\n",
       "\n",
       "table written to memory\n",
       "table end command sent\n",
@@ -299,11 +343,120 @@
     }
    ],
    "source": [
+    "# single_step_test.catch_response()\n",
     "single_step_test.set_mode(sweep_mode=0, timing_mode=1, num_channels=1)\n",
     "single_step_test.allocate(start_address=0, instructions=step_instructions)\n",
     "single_step_test.table_to_memory(instructions=step_instructions)\n",
     "single_step_test.end_table(instructions=step_instructions)\n",
-    "single_step_test.start_routine()\n"
+    "\n",
+    "single_step_test.start_routine()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Binary_Routine_Test.catch_response()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "10"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "conn.write(b'readtable\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# conn.write(b'program\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Instruction Table Dump:\n",
+      "Raw bytes for instruction 0: F2 04 D7 A3 70 3D 05 00 10 06 00 13 03 01 00\n",
+      "Instruction format: F2 04 D7 A3 | 70 3D | 05 00 | 10 06 00 13\n",
+      "Instruction 0: 4060403619 28733 1280 268828691\n",
+      "Raw bytes for instruction 1: F2 04 85 EB 51 38 05 00 10 06 00 10 01 01 00\n",
+      "Instruction format: F2 04 85 EB | 51 38 | 05 00 | 10 06 00 10\n",
+      "Instruction 1: 4060382699 20792 1280 268828688\n",
+      "Raw bytes for instruction 2: F2 04 33 33 33 33 05 00 10 06 00 13 03 01 00\n",
+      "Instruction format: F2 04 33 33 | 33 33 | 05 00 | 10 06 00 13\n",
+      "Instruction 2: 4060361523 13107 1280 268828691\n",
+      "Raw bytes for instruction 3: F2 04 85 EB 51 38 05 00 10 06 00 13 03 00 00\n",
+      "Instruction format: F2 04 85 EB | 51 38 | 05 00 | 10 06 00 13\n",
+      "Instruction 3: 4060382699 20792 1280 268828691\n",
+      "End of Instruction Table\n"
+     ]
+    }
+   ],
+   "source": [
+    "MAX_SIZE = 256\n",
+    "# for _ in range(step_instructions.shape[0] + 2): # + 2 to catch header and footer\n",
+    "for _ in range(MAX_SIZE):\n",
+    "    resp = Binary_Routine_Test.catch_response()\n",
+    "    print(resp)\n",
+    "    if \"End of\" in resp:\n",
+    "        break\n",
+    "    elif \"Cannot\" in resp:\n",
+    "        break\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4123168604"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x = get_ftw(freq_out=120 * MHZ, freq_sys=125 * MHZ)\n",
+    "len(str(x)) == len(str(4060403619)) # true\n",
+    "x"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Binary_Routine_Test.catch_response()"
    ]
   },
   {
@@ -322,7 +475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,24 +510,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sending commands to 1 channels\n",
-      "Got response: ready for 170 bytes\n",
-      "\n",
-      "table written to memory\n",
-      "table end command sent\n",
-      "table executed\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "freq_sweep_test = Binary_Routines()\n",
+    "# print(freq_sweep_test.catch_response())\n",
+    "# freq_sweep_test.debug_on()\n",
     "freq_sweep_test.set_mode(sweep_mode=2, timing_mode=1, num_channels=1)\n",
     "freq_sweep_test.allocate(start_address=0, instructions=freq_sweep_table)\n",
     "freq_sweep_test.table_to_memory(instructions=freq_sweep_table)\n",
@@ -398,7 +540,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,18 +562,18 @@
     "\n",
     "\n",
     "channel0_instructions = np.array([\n",
-    "                                # (0, 0, d, r, t),\n",
-    "                                # (0, 0, d, r, t),\n",
-    "                                # (0, 0, d, r, t),\n",
-    "                                # (0, 0, d, r, t),\n",
-    "                                # (0, 0, d, r, t),\n",
-    "                                # (0, 0, d, r, t)\n",
-    "                                (p0, p2, d, r, t),\n",
-    "                                (p2, p1, d, r, t),\n",
-    "                                (p1, p0, d, r, t),\n",
-    "                                (p0, p1, d, r, t),\n",
-    "                                (p1, p2, d, r, t),\n",
-    "                                (p2, p0, d, r, t)\n",
+    "                                (0, 0, d, r, t),\n",
+    "                                (0, 0, d, r, t),\n",
+    "                                (0, 0, d, r, t),\n",
+    "                                (0, 0, d, r, t),\n",
+    "                                (0, 0, d, r, t),\n",
+    "                                (0, 0, d, r, t)\n",
+    "                                # (p0, p2, d, r, t),\n",
+    "                                # (p2, p1, d, r, t),\n",
+    "                                # (p1, p0, d, r, t),\n",
+    "                                # (p0, p1, d, r, t),\n",
+    "                                # (p1, p2, d, r, t),\n",
+    "                                # (p2, p0, d, r, t)\n",
     "                                 ]\n",
     "                                 , dtype = dt)\n",
     "\n",
@@ -457,22 +599,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sending commands to 2 channels\n",
-      "Got response: ready for 132 bytes\n",
-      "\n",
-      "table written to memory\n",
-      "table end command sent\n",
-      "table executed\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "phase_sweep_test = Binary_Routines()\n",
     "phase_sweep_test.debug_on()\n",
@@ -490,7 +619,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,35 +636,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sending commands to 0 channels\n",
-      "Got response: ready for 66 bytes\n",
-      "\n",
-      "table written to memory\n",
-      "table end command sent\n",
-      "table executed\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "phase_sweep_test = Binary_Routines()\n",
-    "phase_sweep_test.debug_on()\n",
-    "phase_sweep_test.set_mode(sweep_mode=3, timing_mode=1, num_channels=0)\n",
+    "# phase_sweep_test = Binary_Routines()\n",
+    "# phase_sweep_test.debug_on()\n",
+    "# phase_sweep_test.set_mode(sweep_mode=3, timing_mode=1, num_channels=0)\n",
     "\n",
-    "phase_sweep_test.allocate(start_address=0, instructions=channel0_instructions)\n",
-    "phase_sweep_test.table_to_memory(instructions=channel0_instructions)\n",
+    "# phase_sweep_test.allocate(start_address=0, instructions=channel0_instructions)\n",
+    "# phase_sweep_test.table_to_memory(instructions=channel0_instructions)\n",
     "\n",
-    "# phase_sweep_test.allocate(channel=1, instructions=channel1_instructions)\n",
-    "# phase_sweep_test.table_to_memory(instructions=channel1_instructions)\n",
+    "# # phase_sweep_test.allocate(channel=1, instructions=channel1_instructions)\n",
+    "# # phase_sweep_test.table_to_memory(instructions=channel1_instructions)\n",
     "\n",
-    "phase_sweep_test.end_table(instructions=channel0_instructions)\n",
-    "phase_sweep_test.start_routine()"
+    "# phase_sweep_test.end_table(instructions=channel0_instructions)\n",
+    "# phase_sweep_test.start_routine()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conn.write(b'readtable\\n')\n",
+    "# phase_sweep_test.assert_OK()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Binary_Routine_Test.catch_response()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# conn.write(b'program\\n')"
    ]
   },
   {

--- a/testing/tests.ipynb
+++ b/testing/tests.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,9 +84,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Serial Communication Successful\n"
+     ]
+    }
+   ],
    "source": [
     "assert send('reset')    == 'ok\\n'\n",
     "assert send('status')   == '0\\n'\n",
@@ -103,9 +111,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'pll_mult': 4,\n",
+       " 0: {'freq': 0.0, 'phase': 0.0, 'amp': 1},\n",
+       " 1: {'freq': 0.0, 'phase': 0.0, 'amp': 1},\n",
+       " 2: {'freq': 0.0, 'phase': 0.0, 'amp': 1},\n",
+       " 3: {'freq': 0.0, 'phase': 0.0, 'amp': 1}}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Helper for reading register values and putting them in a dictionary\n",
     "# takes in the frequency of the reference clock, assuming default of 125 MHz\n",
@@ -153,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,18 +194,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "pll_mult 4\n",
+      "Channel 0 {'freq': 0.0, 'phase': 0.0, 'amp': 1}\n",
+      "Channel 1 {'freq': 0.0, 'phase': 0.0, 'amp': 1}\n",
+      "Channel 2 {'freq': 0.0, 'phase': 0.0, 'amp': 1}\n",
+      "Channel 3 {'freq': 0.0, 'phase': 0.0, 'amp': 1}\n",
+      "None\n"
+     ]
+    }
+   ],
    "source": [
     "print(parser(readregs()))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Register Readback Successful\n"
+     ]
+    }
+   ],
    "source": [
     "assert send('reset') == 'ok\\n', 'Could not run \"reset\" command'\n",
     "ad9959 = readregs()\n",
@@ -205,8 +249,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scope Class"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +307,7 @@
     "        self.write(f':TIMebase:SCALe {time}')\n",
     "\n",
     "    def annotate_screen(self, message):\n",
-    "        pass\n",
+    "        self.write(f':DISPlay:ANNotation:TEXT \"{message}\"')\n",
     "\n",
     "    def set_math_x_scale(self, x_value):\n",
     "        pass\n",
@@ -278,7 +329,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "27"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# my_instrument.query('*LRN?')\n",
     "# my_instrument.query('TIMebase:MODE?')\n",
@@ -306,8 +368,7 @@
     "\n",
     "my_instrument.write(':FUNCtion:OPERation SUBTract')\n",
     "my_instrument.write(':FUNCtion:OFFSet +500E-03')\n",
-    "my_instrument.write(':FUNCtion:SCALe +1.00E+00')\n",
-    "\n"
+    "my_instrument.write(':FUNCtion:SCALe +1.00E+00')"
    ]
   },
   {
@@ -319,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,9 +420,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ok\\n'"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "## source\n",
     "freq0 = 125 * MHZ # source freq > ref freq\n",
@@ -391,9 +463,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ok\\n'"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# send(f\"\"\"\n",
     "#      abort\n",
@@ -428,9 +511,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ok\\n'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "send('reset')"
    ]
@@ -439,14 +533,25 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ok\\n'"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "freq0 = 100 * MHZ\n",
-    "amp0 = 1\n",
+    "# freq0 = 100 * MHZ\n",
+    "# amp0 = 1\n",
     "\n",
-    "send('setchannels 20')\n",
-    "send(f'setfreq 0 {freq0}')\n",
-    "send(f'setamp 0 {amp0}')\n",
+    "# send('setchannels 20')\n",
+    "# send(f'setfreq 0 {freq0}')\n",
+    "# send(f'setamp 0 {amp0}')\n",
     "# my_instrument.save_screenshot('mirrortest0.png')"
    ]
   },
@@ -454,13 +559,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ok\\n'"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "freq1 = 90 * MHZ\n",
-    "amp1 = .7\n",
+    "# freq1 = 90 * MHZ\n",
+    "# amp1 = .7\n",
     "\n",
-    "# send(f'setfreq 1 {freq1}')\n",
-    "send(f'setamp 1 {amp1}')\n",
+    "# # send(f'setfreq 1 {freq1}')\n",
+    "# send(f'setamp 1 {amp1}')\n",
     "\n",
     "# my_instrument.save_screenshot('mirrortest1.png')\n"
    ]
@@ -474,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +599,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +608,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,14 +653,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table Programmed, Executing\n",
+      "Table Executed successfully\n"
+     ]
+    }
+   ],
    "source": [
     "my_instrument.write(':TIMebase:DELay 20.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 10.0E-09')\n",
     "my_instrument.write(\":CHANnel2:DISPlay 0\")\n",
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Mode 0a: Single Stepping Frequency\"')\n",
+    "my_instrument.annotate_screen('Testing Mode 0a: Single Stepping Frequency')\n",
     "send('reset')\n",
     "\n",
     "startPoint = 10 * MHZ\n",
@@ -588,9 +713,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table Programmed, Executing\n",
+      "Table Executed successfully\n"
+     ]
+    }
+   ],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Mode 0b: Single Stepping Amplitude\"')\n",
+    "my_instrument.annotate_screen(\"Testing Mode 0b: Single Stepping Amplitude\")\n",
     "\n",
     "startFreq = 100 * MHZ\n",
     "startPhase = 0\n",
@@ -636,9 +770,18 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table Programmed, Executing\n",
+      "Table Executed successfully\n"
+     ]
+    }
+   ],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Mode 0c: Single Stepping Phase\"')\n",
+    "my_instrument.annotate_screen(\"Testing Mode 0c: Single Stepping Phase\")\n",
     "\n",
     "startFreq = 100 * MHZ\n",
     "startAmp = 1\n",
@@ -685,9 +828,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Table run from non-volatile memory successfully\n"
+     ]
+    }
+   ],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Table Save and Load\"')\n",
+    "my_instrument.annotate_screen(\"Testing Table Save and Load\")\n",
     "\n",
     "send('save')\n",
     "\n",
@@ -724,9 +875,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success\n"
+     ]
+    }
+   ],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Mode 1\"')\n",
+    "my_instrument.annotate_screen(\"Testing Mode 1\")\n",
     "my_instrument.write(':TIMebase:DELay 35.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 10.0E-06')\n",
     "\n",
@@ -771,7 +930,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,9 +993,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success\n"
+     ]
+    }
+   ],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Mode 2: Frequency Sweep\"')\n",
+    "my_instrument.annotate_screen(\"Testing Mode 2: Frequency Sweep\")\n",
     "my_instrument.write(':TIMebase:DELay 40.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 10.0E-06')\n",
     "send('reset')\n",
@@ -902,9 +1069,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\n'"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "send(\n",
     "f\"\"\"abort\n",
@@ -940,9 +1118,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success\n"
+     ]
+    }
+   ],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Mode 3: Phase Sweep\"')\n",
+    "my_instrument.annotate_screen(\"Testing Mode 3: Phase Sweep\")\n",
     "my_instrument.write(':TIMebase:DELay 35.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 10.0E-06')\n",
     "\n",
@@ -1009,7 +1195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing seti Mode 3: Phase Sweep\"')\n",
+    "my_instrument.annotate_screen(\"Testing seti Mode 3: Phase Sweep\")\n",
     "my_instrument.write(':FUNCtion:OFFSet 1.60E-00')\n",
     "my_instrument.write(':FUNCtion:SCALe +100E-03')\n",
     "send('reset')\n",
@@ -1077,7 +1263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1089,9 +1275,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success\n"
+     ]
+    }
+   ],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing set Mode 4: Amplitude Sweep, Single Step Freq, Phase\"')\n",
+    "my_instrument.annotate_screen(\"Testing set Mode 4: Amplitude Sweep, Single Step Freq, Phase\")\n",
     "my_instrument.write(':TIMebase:DELay 70.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 20.0E-06')\n",
     "my_instrument.write(':FUNCtion:SCALe +2.00E-00')\n",
@@ -1146,9 +1340,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ok\\n'"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "send('reset')"
    ]
@@ -1159,7 +1364,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing seti Mode 4: Amplitude Sweep, Single Step Freq, Phase\"')\n",
+    "my_instrument.annotate_screen(\"Testing seti Mode 4: Amplitude Sweep, Single Step Freq, Phase\")\n",
     "\n",
     "my_instrument.write(':TIMebase:DELay 15.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 10.0E-06')\n",
@@ -1222,9 +1427,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'ok\\n'"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "send('reset')\n"
    ]
@@ -1233,9 +1449,17 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success\n"
+     ]
+    }
+   ],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Mode 5: Frequency Sweep, Single Step Amp, Phase\"')\n",
+    "my_instrument.annotate_screen(\"Testing Mode 5: Frequency Sweep, Single Step Amp, Phase\")\n",
     "\n",
     "my_instrument.write(':TIMebase:DELay 200.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 50.0E-06')\n",
@@ -1307,7 +1531,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing seti Mode 5: Frequency Sweep, Single Step Amp, Phase\"')\n",
+    "my_instrument.annotate_screen(\"Testing seti Mode 5: Frequency Sweep, Single Step Amp, Phase\")\n",
     "\n",
     "my_instrument.write(':TIMebase:DELay 80.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 20.0E-06')\n",
@@ -1391,11 +1615,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
-    "send('reset')"
+    "# send('reset') ## this test seems to draw only after multiple runs??"
    ]
   },
   {
@@ -1404,7 +1628,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing Mode 6: Phase Sweep, Single Step Amp, Freq\"')\n",
+    "my_instrument.annotate_screen(\"Testing Mode 6: Phase Sweep, Single Step Amp, Freq\")\n",
     "\n",
     "my_instrument.write(':TIMebase:DELay 150.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 50.0E-06')\n",
@@ -1525,7 +1749,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing seti Mode 6: Phase Sweep, Single Step Amp, Freq\"')\n",
+    "my_instrument.annotate_screen(\"Testing seti Mode 6: Phase Sweep, Single Step Amp, Freq\")\n",
     "\n",
     "my_instrument.write(':TIMebase:DELay 35.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 10.0E-06')\n",
@@ -1574,9 +1798,20 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "45"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# my_instrument.write(':DISPlay:ANNotation:TEXT \"Testing finished\"')"
+    "my_instrument.annotate_screen(\"Testing finished\")"
    ]
   }
  ],

--- a/testing/tests.ipynb
+++ b/testing/tests.ipynb
@@ -178,45 +178,51 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [],
-   "source": [
-    "def parser(register_dict):\n",
-    "    \"\"\"\n",
-    "    Handler for readregs function to print in human readable form\n",
-    "    \"\"\"\n",
-    "\n",
-    "    for key in register_dict:\n",
-    "        if type(key) == int:\n",
-    "            print('Channel', key, register_dict[key])\n",
-    "        else:\n",
-    "            print(key, register_dict[key])\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "pll_mult 4\n",
-      "Channel 0 {'freq': 0.0, 'phase': 0.0, 'amp': 1}\n",
-      "Channel 1 {'freq': 0.0, 'phase': 0.0, 'amp': 1}\n",
-      "Channel 2 {'freq': 0.0, 'phase': 0.0, 'amp': 1}\n",
-      "Channel 3 {'freq': 0.0, 'phase': 0.0, 'amp': 1}\n",
-      "None\n"
+      "PLL Multiplier: 4\n",
+      "Channel 0:\n",
+      "  Frequency: 0.0 Hz\n",
+      "  Phase: 0.0 degrees\n",
+      "  Amplitude: 1\n",
+      "Channel 1:\n",
+      "  Frequency: 0.0 Hz\n",
+      "  Phase: 0.0 degrees\n",
+      "  Amplitude: 1\n",
+      "Channel 2:\n",
+      "  Frequency: 0.0 Hz\n",
+      "  Phase: 0.0 degrees\n",
+      "  Amplitude: 1\n",
+      "Channel 3:\n",
+      "  Frequency: 0.0 Hz\n",
+      "  Phase: 0.0 degrees\n",
+      "  Amplitude: 1\n"
      ]
     }
    ],
    "source": [
-    "print(parser(readregs()))"
+    "def format_regs(ad9959: dict) -> str:\n",
+    "    formatted_str = []\n",
+    "    formatted_str.append(f\"PLL Multiplier: {ad9959['pll_mult']}\")\n",
+    "    \n",
+    "    for i in range(4):\n",
+    "        formatted_str.append(f\"Channel {i}:\")\n",
+    "        formatted_str.append(f\"  Frequency: {ad9959[i]['freq']} Hz\")\n",
+    "        formatted_str.append(f\"  Phase: {ad9959[i]['phase']} degrees\")\n",
+    "        formatted_str.append(f\"  Amplitude: {ad9959[i]['amp']}\")\n",
+    "    \n",
+    "    return \"\\n\".join(formatted_str)\n",
+    "\n",
+    "ad9959 = readregs()\n",
+    "print(format_regs(ad9959))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -257,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -336,7 +342,7 @@
        "27"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -380,7 +386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +399,8 @@
     "\n",
     "def get_pow(phase: float):\n",
     "    \n",
-    "    pow = round(phase / 360 * (2**14 - 1))\n",
+    "    # pow = round(phase / 360 * (2**14 - 1))\n",
+    "    pow = round(phase / 360 * (2**14))\n",
     "\n",
     "    return pow\n",
     "\n",
@@ -420,7 +427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -429,7 +436,7 @@
        "'ok\\n'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -463,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -472,7 +479,7 @@
        "'ok\\n'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -511,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -520,7 +527,7 @@
        "'ok\\n'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -531,20 +538,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'ok\\n'"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# freq0 = 100 * MHZ\n",
     "# amp0 = 1\n",
@@ -557,20 +553,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'ok\\n'"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# freq1 = 90 * MHZ\n",
     "# amp1 = .7\n",
@@ -590,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -599,7 +584,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +638,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -711,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -768,7 +753,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -826,7 +811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -873,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -930,7 +915,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -991,7 +976,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1006,7 +991,7 @@
     "my_instrument.annotate_screen(\"Testing Mode 2: Frequency Sweep\")\n",
     "my_instrument.write(':TIMebase:DELay 40.0E-06')\n",
     "my_instrument.write(':TIMebase:SCALe 10.0E-06')\n",
-    "send('reset')\n",
+    "# send('reset')\n",
     "\n",
     "filename = 'mode2-freqsweep-test.png'\n",
     "\n",
@@ -1069,7 +1054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1078,7 +1063,7 @@
        "'ok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\n'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1116,7 +1101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -1191,7 +1176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1263,7 +1248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1273,7 +1258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1340,27 +1325,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'ok\\n'"
-      ]
-     },
-     "execution_count": 34,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "send('reset')"
+    "# send('reset')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1427,27 +1401,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'ok\\n'"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "send('reset')\n"
+    "# send('reset')\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1527,7 +1490,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1615,7 +1578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1624,7 +1587,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1745,7 +1708,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1796,20 +1759,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "45"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "my_instrument.annotate_screen(\"Testing finished\")"
    ]


### PR DESCRIPTION
Tackling #51 1., added `get_instructions()` function in firmware to be invoked when sending `readtable`  to the device in PySerial. 

Currently working on a `getmode` and getting the memory layout as a string for numpy structured array. 