### PR TITLE
`getmode` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,35 +208,17 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
         `secondary1` is the frequency, and `secondary2` is the amplitude scale factor.
 
 * `setb <start address:int> <instruction count:int>`:  
-Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent, and helpful numpy datatypes for structured arrays are included below:  
-  - Single Stepping (mode 0): `<frequency:int 32> <amplitude:int 16> <phase:int 16>`. Total of 8 bytes per channel per instruction.
-    - `datatypes = np.dtype([('frequency', '<u4'), ('amplitude', '<u2'), ('phase', '<u2')])`
-  - Single Stepping (mode 0) with timing: `<frequency:int 32> <amplitude:int 16> <phase:int 16> <time: int 32>`. Total of 12 bytes per channel per instruction.
-    - `datatypes = np.dtype([('frequency', '<u4'), ('amplitude', '<u2'), ('phase', '<u2'), ('time', '<u4')])`
-  - Amplitude Sweeps (mode 1): `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8>`. Total of 7 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1')])`
-  - Amplitude Sweeps (mode 1) with timing: `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <time:int 32>`. Total of 11 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('time', '<u4')])`
-  - Frequency Sweeps (mode 2): `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8>`. Total of 13 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1')])`
-  - Frequency Sweeps (mode 2) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <time:int 32>`. Total of 17 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1'), ('time', '<u4')])`
-  - Phase Sweeps (mode 1): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8>`. Total of 7 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1')])`
-  - Phase Sweeps (mode 1) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <time:int 32>`. Total of 11 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('time', '<u4')])`
-  - Amplitude Sweep and Single Stepping (mode 4): `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <phase:int 16>`. Total of 13 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('phase', '<u2')])`
-  - Amplitude Sweep and Single Stepping (mode 4) with timing: `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <phase:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('phase', '<u2'), ('time', '<u4')])`
-  - Frequency Sweep and Single Stepping (mode 5): `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <amplitude:int 16> <phase:int 16>`. Total of 17 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1'), ('amplitude', '<u2'), ('phase', '<u2')])`
-  - Frequency Sweep and Single Stepping (mode 5) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <amplitude:int 16> <phase:int 16> <time:int 32>`. Total of 21 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1'), ('amplitude', '<u2'), ('phase', '<u2'), ('time', '<u4')])`
-  - Phase Sweep and Single Stepping (mode 6): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16>`. Total of 13 bytes per channel per instruction.  
-    - `datatypes = np.dtype([('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('amplitude', '<u2')])`
-  - Phase Sweep and Single Stepping (mode 6) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.
-    - `datatypes = np.dtype([('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('amplitude', '<u2'), ('time', '<u4')])`
+Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent, and in the table below each mode is assumed to use external timing (with internal timing is in parentheses, in this case, append `, ('time', '<u4')` to the end of the np.dtype list)
+
+| Mode  | Bytes per channel per instruction  | np.dtype  |
+|---| :---: |:---:|
+| Single Stepping (mode 0)  | 8 (12) | `[('frequency', '<u4'), ('amplitude', '<u2'), ('phase', '<u2')]`  |
+| Amplitude Sweeps (mode 1)  | 7 (11) |  `[('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1')]` |
+| Frequency Sweeps (mode 2) | 13 (17) |  `[('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1')]` |
+| Phase Sweeps (mode 3)  | 7 (11) | `[('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1')]` |
+| Amplitude Sweep and Single Stepping (mode 4) | 13 (17)  | `[('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('phase', '<u2')]`  |
+| Frequency Sweep and Single Stepping (mode 5) | 17 (21) | `[('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1'), ('amplitude', '<u2'), ('phase', '<u2')]`  |
+| Phase Sweep and Single Stepping (mode 6)  | 13 (17) | `[('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('amplitude', '<u2')]`  |
 
 ### Flash commands
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
         `secondary1` is the frequency, and `secondary2` is the amplitude scale factor.
 
 * `setb <start address:int> <instruction count:int>`:  
-Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent, and in the table below each mode is assumed to use external timing (with internal timing is in parentheses, in this case, append `, ('time', '<u4')` to the end of the np.dtype list)
+Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent, and in the table below each mode is assumed to use external timing (where internal timing bytes are in parentheses and the dtype list must have `, ('time', '<u4')` appended)
 
 | Mode  | Bytes per channel per instruction  | np.dtype  |
 |---| :---: |:---:|

--- a/README.md
+++ b/README.md
@@ -208,21 +208,35 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
         `secondary1` is the frequency, and `secondary2` is the amplitude scale factor.
 
 * `setb <start address:int> <instruction count:int>`:  
-Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent:  
-   - Single Stepping (mode 0): `<frequency:int 32> <amplitude:int 16> <phase:int 16>`. Total of 8 bytes per channel per instruction.  
-   - Single Stepping (mode 0) with timing: `<frequency:int 32> <amplitude:int 16> <phase:int 16> <time: int 32>`. Total of 12 bytes per channel per instruction.  
-   - Amplitude Sweeps (mode 1): `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8>`. Total of 7 bytes per channel per instruction.  
-   - Amplitude Sweeps (mode 1) with timing: `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <time:int 32>`. Total of 11 bytes per channel per instruction.  
-   - Frequency Sweeps (mode 2): `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8>`. Total of 13 bytes per channel per instruction.  
-   - Frequency Sweeps (mode 2) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <time:int 32>`. Total of 17 bytes per channel per instruction.  
-   - Phase Sweeps (mode 1): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8>`. Total of 7 bytes per channel per instruction.  
-   - Phase Sweeps (mode 1) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <time:int 32>`. Total of 11 bytes per channel per instruction.  
-   - Amplitude Sweep and Single Stepping (mode 4): `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <phase:int 16>`. Total of 13 bytes per channel per instruction.  
-   - Amplitude Sweep and Single Stepping (mode 4) with timing: `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <phase:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.  
-   - Frequency Sweep and Single Stepping (mode 5): `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <amplitude:int 16> <phase:int 16>`. Total of 17 bytes per channel per instruction.  
-   - Frequency Sweep and Single Stepping (mode 5) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <amplitude:int 16> <phase:int 16> <time:int 32>`. Total of 21 bytes per channel per instruction.  
-   - Phase Sweep and Single Stepping (mode 6): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16>`. Total of 13 bytes per channel per instruction.  
-   - Phase Sweep and Single Stepping (mode 6) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.
+Bulk setting of instructions in binary. `start address` is the address of the first instruction loaded. `instruction count` instructions will be programmed. If there is not sufficient space for that many instructions, the response will be an error message. Otherwise, the response will be `ready for <byte count:int> bytes`, where `byte count` is the number of bytes the device is expecting. An array of instructions can then be transmitted. Note that all active channels are loaded together. The layout of the instruction array is mode dependent, and helpful numpy datatypes for structured arrays are included below:  
+  - Single Stepping (mode 0): `<frequency:int 32> <amplitude:int 16> <phase:int 16>`. Total of 8 bytes per channel per instruction.
+    - `datatypes = np.dtype([('frequency', '<u4'), ('amplitude', '<u2'), ('phase', '<u2')])`
+  - Single Stepping (mode 0) with timing: `<frequency:int 32> <amplitude:int 16> <phase:int 16> <time: int 32>`. Total of 12 bytes per channel per instruction.
+    - `datatypes = np.dtype([('frequency', '<u4'), ('amplitude', '<u2'), ('phase', '<u2'), ('time', '<u4')])`
+  - Amplitude Sweeps (mode 1): `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8>`. Total of 7 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1')])`
+  - Amplitude Sweeps (mode 1) with timing: `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <time:int 32>`. Total of 11 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('time', '<u4')])`
+  - Frequency Sweeps (mode 2): `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8>`. Total of 13 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1')])`
+  - Frequency Sweeps (mode 2) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <time:int 32>`. Total of 17 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1'), ('time', '<u4')])`
+  - Phase Sweeps (mode 1): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8>`. Total of 7 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1')])`
+  - Phase Sweeps (mode 1) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <time:int 32>`. Total of 11 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('time', '<u4')])`
+  - Amplitude Sweep and Single Stepping (mode 4): `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <phase:int 16>`. Total of 13 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('phase', '<u2')])`
+  - Amplitude Sweep and Single Stepping (mode 4) with timing: `<start amplitude:int 16> <stop amplitude:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <phase:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_amplitude', '<u2'), ('stop_amplitude', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('phase', '<u2'), ('time', '<u4')])`
+  - Frequency Sweep and Single Stepping (mode 5): `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <amplitude:int 16> <phase:int 16>`. Total of 17 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1'), ('amplitude', '<u2'), ('phase', '<u2')])`
+  - Frequency Sweep and Single Stepping (mode 5) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <amplitude:int 16> <phase:int 16> <time:int 32>`. Total of 21 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_frequency', '<u4'), ('stop_frequency', '<u4'), ('delta', '<u4'), ('rate', '<u1'), ('amplitude', '<u2'), ('phase', '<u2'), ('time', '<u4')])`
+  - Phase Sweep and Single Stepping (mode 6): `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16>`. Total of 13 bytes per channel per instruction.  
+    - `datatypes = np.dtype([('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('amplitude', '<u2')])`
+  - Phase Sweep and Single Stepping (mode 6) with timing: `<start phase:int 16> <stop phase:int 16> <delta:int 16> <rate:int 8> <frequency:int 32> <amplitude:int 16> <time:int 32>`. Total of 17 bytes per channel per instruction.
+    - `datatypes = np.dtype([('start_phase', '<u2'), ('stop_phase', '<u2'), ('delta', '<u2'), ('rate', '<u1'), ('frequency', '<u4'), ('amplitude', '<u2'), ('time', '<u4')])`
 
 ### Flash commands
 

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -746,84 +746,82 @@ void parse_phase_sweep_ins(uint addr, uint channel,
 
 
 void get_memory_layout(uint sweep_mode) {
-    // Each prints with timing since it's trivial to remove -- Do we want to handle that?
-    char datatypes[4096] = "datatypes = np.dtype([";
-    char channel_datatype[256];
 
-    // Print mode information only once
+    fast_serial_printf("%d active channels\n", ad9959.channels);
     switch (sweep_mode) {
         case 0:
             fast_serial_printf("Mode 0 - Single Steps\n");
+            fast_serial_printf("datatypes = np.dtype([");
+            fast_serial_printf("('frequency', '<u4'), ");
+            fast_serial_printf("('amplitude', '<u2'), ");
+            fast_serial_printf("('phase', '<u2'), ");
+            fast_serial_printf("('time', '<u4')");
             break;
         case 1:
             fast_serial_printf("Mode 1 - Amplitude Sweeps\n");
+            fast_serial_printf("datatypes = np.dtype([");
+            fast_serial_printf("('start_amplitude', '<u2'), ");
+            fast_serial_printf("('stop_amplitude', '<u2'), ");
+            fast_serial_printf("('delta', '<u2'), ");
+            fast_serial_printf("('rate', '<u1'), ");
+            fast_serial_printf("('time', '<u4')");
             break;
         case 2:
             fast_serial_printf("Mode 2 - Frequency Sweeps\n");
+            fast_serial_printf("datatypes = np.dtype([");
+            fast_serial_printf("('start_frequency', '<u4'), ");
+            fast_serial_printf("('stop_frequency', '<u4'), ");
+            fast_serial_printf("('delta', '<u4'), ");
+            fast_serial_printf("('rate', '<u1'), ");
+            fast_serial_printf("('time', '<u4')");
             break;
         case 3:
             fast_serial_printf("Mode 3 - Phase Sweeps\n");
+            fast_serial_printf("datatypes = np.dtype([");
+            fast_serial_printf("('start_phase', '<u2'), ");
+            fast_serial_printf("('stop_phase', '<u2'), ");
+            fast_serial_printf("('delta', '<u2'), ");
+            fast_serial_printf("('rate', '<u1'), ");
+            fast_serial_printf("('time', '<u4')");
             break;
         case 4:
             fast_serial_printf("Mode 4 - Amplitude2 Sweeps\n");
+            fast_serial_printf("datatypes = np.dtype([");
+            fast_serial_printf("('start_amplitude', '<u2'), ");
+            fast_serial_printf("('stop_amplitude', '<u2'), ");
+            fast_serial_printf("'delta', '<u2'), ");
+            fast_serial_printf("('rate', '<u1'), ");
+            fast_serial_printf("('frequency', '<u4'), ");
+            fast_serial_printf("('phase', '<u2'), ");
+            fast_serial_printf("('time', '<u4')");
             break;
         case 5:
             fast_serial_printf("Mode 5 - Frequency2 Sweeps\n");
+            fast_serial_printf("datatypes = np.dtype([");
+            fast_serial_printf("('start_frequency', '<u4'), ");
+            fast_serial_printf("('stop_frequency', '<u4'), ");
+            fast_serial_printf("('delta', '<u4'), ");
+            fast_serial_printf("('rate', '<u1'), ");
+            fast_serial_printf("('amplitude', '<u2'), ");
+            fast_serial_printf("('phase', '<u2'), ");
+            fast_serial_printf("('time', '<u4')");
             break;
         case 6:
             fast_serial_printf("Mode 6 - Phase2 Sweeps\n");
+            fast_serial_printf("datatypes = np.dtype([");
+            fast_serial_printf("('start_phase', '<u2'), ");
+            fast_serial_printf("('stop_phase', '<u2'), ");
+            fast_serial_printf("'delta, '<u2'), ");
+            fast_serial_printf("('rate, '<u1'), ");  
+            fast_serial_printf("('frequency', '<u4'), ");  
+            fast_serial_printf("('amplitude', '<u2'), ");  
+            fast_serial_printf("('time', '<u4')");  
             break;
         default:
             fast_serial_printf("Couldn't find mode info\n");
             return;
     }
-
-    // Get dtype for each active channel
-    for (uint i = 0; i < ad9959.channels; i++) {
-        switch (sweep_mode) {
-            case 0:
-                sprintf(channel_datatype, "('frequency%d', np.uint32), ('amplitude%d', np.uint16), ('phase%d', np.uint16), ('time%d', np.uint32), ", i, i, i, i);
-                break;
-            case 1:
-                sprintf(channel_datatype, "('start amplitude%d', np.uint16), ('stop amplitude%d', np.uint16), ('delta%d', np.uint16), ('rate%d', np.uint8), ('time%d', np.uint32), ", i, i, i, i, i);
-                break;
-            case 2:
-                sprintf(channel_datatype, "('start frequency%d', np.uint32), ('stop frequency%d', np.uint32), ('delta%d', np.uint32), ('rate%d', np.uint8), ('time%d', np.uint32), ", i, i, i, i, i);
-                break;
-            case 3:
-                sprintf(channel_datatype, "('start phase%d', np.uint16), ('stop phase%d', np.uint16), ('delta%d', np.uint16), ('rate%d', np.uint8), ('time%d', np.uint32), ", i, i, i, i, i);
-                break;
-            case 4:
-                sprintf(channel_datatype, "('start amplitude%d', np.uint16), ('stop amplitude%d', np.uint16), ('delta%d', np.uint16), ('rate%d', np.uint8), ('frequency%d', np.uint32), ('phase%d', np.uint16), ('time%d', np.uint32), ", i, i, i, i, i, i, i);
-                break;
-            case 5:
-                sprintf(channel_datatype, "('start frequency%d', np.uint32), ('stop frequency%d', np.uint32), ('delta%d', np.uint32), ('rate%d', np.uint8), ('amplitude%d', np.uint16), ('phase%d', np.uint16), ('time%d', np.uint32), ", i, i, i, i, i, i, i);
-                break;
-            case 6:
-                sprintf(channel_datatype, "('start phase%d', np.uint16), ('stop phase%d', np.uint16), ('delta%d', np.uint16), ('rate%d', np.uint8), ('frequency%d', np.uint32), ('amplitude%d', np.uint16), ('time%d', np.uint32), ", i, i, i, i, i, i, i);
-                break;
-            default:
-                fast_serial_printf("Couldn't find mode info\n");
-                return;
-        }
-        strcat(datatypes, channel_datatype);
-    }
-
-    // Trailing comma + space, then close array
-    datatypes[strlen(datatypes) - 2] = '\0';
-    strcat(datatypes, "])\n");
-
-    fast_serial_printf("Active channels: %d\n", ad9959.channels);
-
-    // Chunk response since some of those strings are longer than 128 
-    const size_t chunk_size = 128;
-    size_t datatypes_len = strlen(datatypes);
-    for (size_t offset = 0; offset < datatypes_len; offset += chunk_size) {
-        char chunk[chunk_size + 1];
-        strncpy(chunk, datatypes + offset, chunk_size);
-        chunk[chunk_size] = '\0';
-        fast_serial_printf("%s", chunk);
-    }
+    fast_serial_printf("])\n");
 }
 
 // =============================================================================

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -751,71 +751,24 @@ void get_memory_layout(uint sweep_mode) {
     switch (sweep_mode) {
         case 0:
             fast_serial_printf("Mode 0 - Single Steps\n");
-            fast_serial_printf("datatypes = np.dtype([");
-            fast_serial_printf("('frequency', '<u4'), ");
-            fast_serial_printf("('amplitude', '<u2'), ");
-            fast_serial_printf("('phase', '<u2'), ");
-            fast_serial_printf("('time', '<u4')");
             break;
         case 1:
             fast_serial_printf("Mode 1 - Amplitude Sweeps\n");
-            fast_serial_printf("datatypes = np.dtype([");
-            fast_serial_printf("('start_amplitude', '<u2'), ");
-            fast_serial_printf("('stop_amplitude', '<u2'), ");
-            fast_serial_printf("('delta', '<u2'), ");
-            fast_serial_printf("('rate', '<u1'), ");
-            fast_serial_printf("('time', '<u4')");
             break;
         case 2:
             fast_serial_printf("Mode 2 - Frequency Sweeps\n");
-            fast_serial_printf("datatypes = np.dtype([");
-            fast_serial_printf("('start_frequency', '<u4'), ");
-            fast_serial_printf("('stop_frequency', '<u4'), ");
-            fast_serial_printf("('delta', '<u4'), ");
-            fast_serial_printf("('rate', '<u1'), ");
-            fast_serial_printf("('time', '<u4')");
             break;
         case 3:
             fast_serial_printf("Mode 3 - Phase Sweeps\n");
-            fast_serial_printf("datatypes = np.dtype([");
-            fast_serial_printf("('start_phase', '<u2'), ");
-            fast_serial_printf("('stop_phase', '<u2'), ");
-            fast_serial_printf("('delta', '<u2'), ");
-            fast_serial_printf("('rate', '<u1'), ");
-            fast_serial_printf("('time', '<u4')");
             break;
         case 4:
             fast_serial_printf("Mode 4 - Amplitude2 Sweeps\n");
-            fast_serial_printf("datatypes = np.dtype([");
-            fast_serial_printf("('start_amplitude', '<u2'), ");
-            fast_serial_printf("('stop_amplitude', '<u2'), ");
-            fast_serial_printf("'delta', '<u2'), ");
-            fast_serial_printf("('rate', '<u1'), ");
-            fast_serial_printf("('frequency', '<u4'), ");
-            fast_serial_printf("('phase', '<u2'), ");
-            fast_serial_printf("('time', '<u4')");
             break;
         case 5:
             fast_serial_printf("Mode 5 - Frequency2 Sweeps\n");
-            fast_serial_printf("datatypes = np.dtype([");
-            fast_serial_printf("('start_frequency', '<u4'), ");
-            fast_serial_printf("('stop_frequency', '<u4'), ");
-            fast_serial_printf("('delta', '<u4'), ");
-            fast_serial_printf("('rate', '<u1'), ");
-            fast_serial_printf("('amplitude', '<u2'), ");
-            fast_serial_printf("('phase', '<u2'), ");
-            fast_serial_printf("('time', '<u4')");
             break;
         case 6:
             fast_serial_printf("Mode 6 - Phase2 Sweeps\n");
-            fast_serial_printf("datatypes = np.dtype([");
-            fast_serial_printf("('start_phase', '<u2'), ");
-            fast_serial_printf("('stop_phase', '<u2'), ");
-            fast_serial_printf("'delta, '<u2'), ");
-            fast_serial_printf("('rate, '<u1'), ");  
-            fast_serial_printf("('frequency', '<u4'), ");  
-            fast_serial_printf("('amplitude', '<u2'), ");  
-            fast_serial_printf("('time', '<u4')");  
             break;
         default:
             fast_serial_printf("Couldn't find mode info\n");

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -773,8 +773,7 @@ void get_memory_layout(uint sweep_mode) {
             fast_serial_printf("Couldn't find mode info\n");
             return;
     }
-    fast_serial_printf("])\n");
-  
+}
 void get_instructions(void) {
     fast_serial_printf("Instruction Table Dump:\n"); // header
 

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -743,6 +743,88 @@ void parse_phase_sweep_ins(uint addr, uint channel,
     set_phase_sweep_ins(addr, channel, pow_start, pow_end, delta, rate, ftw, asf);
 }
 
+
+void get_memory_layout(uint sweep_mode) {
+    // Each prints with timing since it's trivial to remove -- Do we want to handle that?
+    char datatypes[4096] = "datatypes = np.dtype([";
+    char channel_datatype[256];
+
+    // Print mode information only once
+    switch (sweep_mode) {
+        case 0:
+            fast_serial_printf("Mode 0 - Single Steps\n");
+            break;
+        case 1:
+            fast_serial_printf("Mode 1 - Amplitude Sweeps\n");
+            break;
+        case 2:
+            fast_serial_printf("Mode 2 - Frequency Sweeps\n");
+            break;
+        case 3:
+            fast_serial_printf("Mode 3 - Phase Sweeps\n");
+            break;
+        case 4:
+            fast_serial_printf("Mode 4 - Amplitude2 Sweeps\n");
+            break;
+        case 5:
+            fast_serial_printf("Mode 5 - Frequency2 Sweeps\n");
+            break;
+        case 6:
+            fast_serial_printf("Mode 6 - Phase2 Sweeps\n");
+            break;
+        default:
+            fast_serial_printf("Couldn't find mode info\n");
+            return;
+    }
+
+    // Get dtype for each active channel
+    for (uint i = 0; i < ad9959.channels; i++) {
+        switch (sweep_mode) {
+            case 0:
+                sprintf(channel_datatype, "('frequency%d', np.uint32), ('amplitude%d', np.uint16), ('phase%d', np.uint16), ('time%d', np.uint32), ", i, i, i, i);
+                break;
+            case 1:
+                sprintf(channel_datatype, "('start amplitude%d', np.uint16), ('stop amplitude%d', np.uint16), ('delta%d', np.uint16), ('rate%d', np.uint8), ('time%d', np.uint32), ", i, i, i, i, i);
+                break;
+            case 2:
+                sprintf(channel_datatype, "('start frequency%d', np.uint32), ('stop frequency%d', np.uint32), ('delta%d', np.uint32), ('rate%d', np.uint8), ('time%d', np.uint32), ", i, i, i, i, i);
+                break;
+            case 3:
+                sprintf(channel_datatype, "('start phase%d', np.uint16), ('stop phase%d', np.uint16), ('delta%d', np.uint16), ('rate%d', np.uint8), ('time%d', np.uint32), ", i, i, i, i, i);
+                break;
+            case 4:
+                sprintf(channel_datatype, "('start amplitude%d', np.uint16), ('stop amplitude%d', np.uint16), ('delta%d', np.uint16), ('rate%d', np.uint8), ('frequency%d', np.uint32), ('phase%d', np.uint16), ('time%d', np.uint32), ", i, i, i, i, i, i, i);
+                break;
+            case 5:
+                sprintf(channel_datatype, "('start frequency%d', np.uint32), ('stop frequency%d', np.uint32), ('delta%d', np.uint32), ('rate%d', np.uint8), ('amplitude%d', np.uint16), ('phase%d', np.uint16), ('time%d', np.uint32), ", i, i, i, i, i, i, i);
+                break;
+            case 6:
+                sprintf(channel_datatype, "('start phase%d', np.uint16), ('stop phase%d', np.uint16), ('delta%d', np.uint16), ('rate%d', np.uint8), ('frequency%d', np.uint32), ('amplitude%d', np.uint16), ('time%d', np.uint32), ", i, i, i, i, i, i, i);
+                break;
+            default:
+                fast_serial_printf("Couldn't find mode info\n");
+                return;
+        }
+        strcat(datatypes, channel_datatype);
+    }
+
+    // Trailing comma + space, then close array
+    datatypes[strlen(datatypes) - 2] = '\0';
+    strcat(datatypes, "])\n");
+
+    fast_serial_printf("Active channels: %d\n", ad9959.channels);
+
+    // Chunk response since some of those strings are longer than 128 
+    const size_t chunk_size = 128;
+    size_t datatypes_len = strlen(datatypes);
+    for (size_t offset = 0; offset < datatypes_len; offset += chunk_size) {
+        char chunk[chunk_size + 1];
+        strncpy(chunk, datatypes + offset, chunk_size);
+        chunk[chunk_size] = '\0';
+        fast_serial_printf("%s", chunk);
+    }
+}
+
 // =============================================================================
 // Table Running Loop
 // =============================================================================
@@ -887,6 +969,8 @@ void loop() {
         flash_range_program(FLASH_TARGET_OFFSET, instructions, MAX_SIZE);
         restore_interrupts(ints);
         OK();
+    } else if (strncmp(readstring, "getmode", 7) == 0) {
+        get_memory_layout(ad9959.sweep_type);
     } else if (strncmp(readstring, "setchannels", 11) == 0) {
         uint channels;
 

--- a/testing/KeysightScope.py
+++ b/testing/KeysightScope.py
@@ -1,0 +1,69 @@
+import pyvisa
+
+class KeysightScope:
+    """
+    Helper class using pyvisa for a USB connected Keysight Oscilloscope 
+    """
+    def __init__(self, 
+                 addr='USB?*::INSTR',
+                 timeout=1, 
+                 termination='\n'
+                 ):
+        rm = pyvisa.ResourceManager()
+        devs = rm.list_resources(addr)
+        assert len(devs), "pyvisa didn't find any connected devices matching " + addr
+        self.dev = rm.open_resource(devs[0])
+        self.dev.timeout = 15_000 * timeout
+        self.dev.read_termination = termination
+        self.idn = self.dev.query('*IDN?')
+        self.read = self.dev.read
+        self.write = self.dev.write
+        self.query = self.dev.query
+
+    def _get_screenshot(self, verbose=False):
+        if verbose == True:
+            print('Acquiring screen image...')
+        return(self.dev.query_binary_values(':DISPlay:DATA? PNG, COLor', datatype='s'))
+
+    def save_screenshot(self, filepath: str, verbose=False, inksaver=False):
+        if verbose == True:
+            print('Saving screen image...')
+        result = self._get_screenshot()
+
+        # Keysight scope defaults to inksaving for image save
+        if inksaver == True:
+            self.dev.write(':HARDcopy:INKSaver 1')
+        else: 
+            self.dev.write(':HARDcopy:INKSaver OFF')
+
+        with open(f'{filepath}', 'wb+') as ofile:
+            ofile.write(bytes(result))
+
+    def set_time_delay(self, time: float):
+        
+        self.write(f':TIMebase:DELay {time}')
+
+    def set_time_scale(self, time: float):
+        self.write(f':TIMebase:SCALe {time}')
+
+    def annotate_screen(self, message: str):
+        self.write(f':DISPlay:ANNotation:TEXT "{message}"')
+
+    def set_math_scale(self, scale: float):
+        self.write(f'FUNCtion:SCALe {scale}')
+
+    def set_math_offset(self, offset: float):
+        self.write(f'FUNCtion:OFFSet {offset}')
+
+    def channel_state(self, channel: int, state: int):
+        """
+        Turn on or off a channel
+        state: int (ON: 1 or OFF: 0)
+        """
+        self.write(f':CHANnel{channel}:DISPlay {state}')
+
+    def set_channel_offset(self, channel: int, y_offset: float):
+        self.write(f':CHANnel{channel}:OFFSet {y_offset}')
+
+    def set_channel_scale(self, channel: int, y_scale: float):
+        self.write(f':CHANnel{channel}:SCALe {y_scale}')

--- a/testing/binary-tests.ipynb
+++ b/testing/binary-tests.ipynb
@@ -1,0 +1,336 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import serial\n",
+    "import time\n",
+    "import pyvisa \n",
+    "import numpy as np\n",
+    "from IPython.display import Image, display\n",
+    "from KeysightScope import KeysightScope\n",
+    "\n",
+    "# You will have to change this to whatever COM port the pico is assigned when\n",
+    "# you plug it in.\n",
+    "# On Windows you can open device manager and look at the 'Ports (COM & LPT)' dropdown\n",
+    "# the pico will show up as 'USB Serial Device'\n",
+    "PICO_PORT = 'COM3'\n",
+    "\n",
+    "MHZ = 1000000\n",
+    "\n",
+    "conn = None\n",
+    "conn = serial.Serial(PICO_PORT, baudrate = 152000, timeout = 0.1)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_instrument = KeysightScope()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class BinaryRoutines():\n",
+    "    def __init__(self):\n",
+    "        self.mirror_channels = False\n",
+    "\n",
+    "    def catch_response(self):\n",
+    "        resp = conn.readline().decode().strip()\n",
+    "        return resp\n",
+    "    \n",
+    "    def assert_OK(self):\n",
+    "        resp = conn.readline().decode().strip()\n",
+    "        assert resp == 'ok', 'Expected \"ok\", received \"%s\"' % resp\n",
+    "\n",
+    "    def debug_on(self):\n",
+    "        conn.write(b'debug on\\n')\n",
+    "        self.assert_OK()\n",
+    "\n",
+    "    def set_mode(self, sweep_mode: int, timing_mode: int, num_channels: int):\n",
+    "        conn.write(b'reset\\n')\n",
+    "        self.assert_OK()\n",
+    "        conn.write(b'mode %d %d \\n' % (sweep_mode, timing_mode))\n",
+    "        self.assert_OK()\n",
+    "        conn.write(b'setchannels %d\\n' % num_channels)\n",
+    "        self.assert_OK()\n",
+    "        print('sending commands to %d channels' % num_channels)\n",
+    "\n",
+    "    def allocate(self, start_address: int, instructions: np.ndarray):\n",
+    "        conn.write(b'setb %d %d\\n' % (start_address, len(instructions)))\n",
+    "        response = conn.readline().decode()\n",
+    "        if not response.startswith('ready'):\n",
+    "            response += ''.join([r.decode() for r in conn.readlines()])\n",
+    "            raise Exception(f'setb command failed, response: {repr(response)}')\n",
+    "        print(f'Got response: {response}')\n",
+    "\n",
+    "    def table_to_memory(self, instructions: np.ndarray):\n",
+    "        conn.write(instructions.tobytes())\n",
+    "        self.assert_OK(), 'table not written correctly'\n",
+    "        print('table written to memory')\n",
+    "\n",
+    "    def end_table(self, instructions: np.ndarray):\n",
+    "        conn.write(b'set 4 %d\\n' % len(instructions))\n",
+    "        self.assert_OK(), 'table not stopped correctly'\n",
+    "        print('table end command sent')\n",
+    "\n",
+    "    def start_routine(self):\n",
+    "        conn.write(b'start\\n')\n",
+    "        self.assert_OK(), 'table did not start'\n",
+    "        print('table executed')\n",
+    "\n",
+    "    def get_memory_layout(self):\n",
+    "        conn.write(b'getmode\\n')\n",
+    "        mode = self.catch_response()\n",
+    "        channels = self.catch_response()\n",
+    "        memory_layout = self.catch_response()\n",
+    "        print(f\"mode {mode}\")\n",
+    "        print(channels)\n",
+    "        print(memory_layout)\n",
+    "\n",
+    "binary_routine_test = BinaryRoutines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## slightly different logic than the ad9959.c funcs due to python vs c\n",
+    "def get_ftw(freq_out: float, freq_sys: float = 500 * MHZ):\n",
+    "\n",
+    "    ftw = (freq_out / freq_sys) * 2**32\n",
+    "    \n",
+    "    return(int(ftw))\n",
+    "\n",
+    "def get_pow(phase: float):\n",
+    "    \n",
+    "    pow = round(phase / 360 * (2**14 - 1))\n",
+    "\n",
+    "    return pow\n",
+    "\n",
+    "def get_asf(amp: float):\n",
+    "    \n",
+    "    asf = round(amp * 1024)\n",
+    "\n",
+    "    return asf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Single Stepping Mode"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Single Stepping (mode 0) with timing: `<frequency:int 32> <amplitude:int 16> <phase:int 16> <time: int 32>`. Total of 12 bytes per channel per instruction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = np.dtype([('frequency', np.uint32), ('amplitude', np.uint16), ('phase', np.uint16), ('time', np.uint32)])\n",
+    "\n",
+    "f1 = get_ftw(freq_out = 100 * MHZ)\n",
+    "f2 = get_ftw(freq_out = 120 * MHZ)\n",
+    "f3 = get_ftw(freq_out = 110 * MHZ)\n",
+    "\n",
+    "p1 = get_pow(phase = 90)\n",
+    "p2 = get_pow(phase = 180)\n",
+    "p3 = get_pow(phase = 270)\n",
+    "\n",
+    "t = 1\n",
+    "\n",
+    "step_instructions = np.array([\n",
+    "                                (f2, 1023, p1, t),\n",
+    "                                (f2, 800, p1, t),\n",
+    "                                (f2, 1023, p1, t),\n",
+    "                                (f2, 200, p1, t),\n",
+    "                                (f2, 800, p1, t),\n",
+    "                                (f2, 1023, p1, t),\n",
+    "                                (f2, 200, p1, t),\n",
+    "                                (f2, 800, p1, t),\n",
+    "                                (f2, 1023, p1, t),\n",
+    "                                (f2, 800, p1, t)\n",
+    "                                 ]\n",
+    "                                 , dtype = dt)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "single_step_test = BinaryRoutines()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sending commands to 1 channels\n",
+      "Got response: ready for 120 bytes\n",
+      "\n",
+      "table written to memory\n",
+      "table end command sent\n",
+      "table executed\n"
+     ]
+    }
+   ],
+   "source": [
+    "single_step_test.set_mode(sweep_mode=0, timing_mode=1, num_channels=1)\n",
+    "single_step_test.allocate(start_address=0, instructions=step_instructions)\n",
+    "single_step_test.table_to_memory(instructions=step_instructions)\n",
+    "single_step_test.end_table(instructions=step_instructions)\n",
+    "single_step_test.start_routine()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Frequency Sweeps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Frequency Sweeps (mode 2) with timing: `<start frequency:int 32> <stop frequency:int 32> <delta:int 32> <rate:int 8> <time:int 32>`. Total of 17 bytes per channel per instruction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = np.dtype([('start frequency', np.uint32), \n",
+    "               ('stop frequency', np.uint32), \n",
+    "               ('delta', np.uint32), \n",
+    "               ('rate', np.uint8), \n",
+    "               ('time', np.uint32)])\n",
+    "\n",
+    "f1 = get_ftw(freq_out = 100 * MHZ)\n",
+    "f2 = get_ftw(freq_out = 120 * MHZ)\n",
+    "f3 = get_ftw(freq_out = 110 * MHZ)\n",
+    "\n",
+    "d = 100\n",
+    "r = 1\n",
+    "t = 1\n",
+    "\n",
+    "freq_sweep_table = np.array([\n",
+    "                            (f1, f3, d, r, t),\n",
+    "                            (f3, f2, d, r, t),\n",
+    "                            (f2, f1, d, r, t),\n",
+    "                            (f1, f1, d, r, t),\n",
+    "                            (f2, f2, d, r, t),\n",
+    "                            (f3, f3, d, r, t),\n",
+    "                            (f3, f1, d, r, t),\n",
+    "                            (f1, f2, d, r, t),\n",
+    "                            (f2, f3, d, r, t),\n",
+    "                            (f1, f1, d, r, t),\n",
+    "                                 ]\n",
+    "                                 , dtype = dt)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sending commands to 1 channels\n",
+      "Got response: ready for 170 bytes\n",
+      "\n",
+      "table written to memory\n",
+      "table end command sent\n",
+      "table executed\n"
+     ]
+    }
+   ],
+   "source": [
+    "freq_sweep_test = BinaryRoutines()\n",
+    "freq_sweep_test.set_mode(sweep_mode=2, timing_mode=1, num_channels=1)\n",
+    "freq_sweep_test.allocate(start_address=0, instructions=freq_sweep_table)\n",
+    "freq_sweep_test.table_to_memory(instructions=freq_sweep_table)\n",
+    "freq_sweep_test.end_table(instructions=freq_sweep_table)\n",
+    "freq_sweep_test.start_routine()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "''"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "binary_routine_test.catch_response()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Example:

`print(send('getmode'))`

returns: 
```
Mode 5 - Frequency2 Sweeps
Active channels: 2
datatypes = np.dtype([('start frequency0', np.uint32), ('stop frequency0', np.uint32), ('delta0', np.uint32), ('rate0', np.uint), ('amplitude0', np.uint16), ('phase0', np.uint16), ('time0', np.uint32), ('start frequency1', np.uint32), ('stop frequency1',np.uint32), ('delta1', np.uint32), ('rate1', np.uint8), ('amplitude1', np.uint16), ('phase1', np.uint16), ('time1', np.uint32)]
```
(I'm happy to add newlines to this for readability if need be)