### PR TITLE
Set time as float in `set`

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Retrieves the buffered execution table stored in nonvolatile memory and restores
 ### Debugging commands
 
 * `debug <state:str>`:  
-Turns on extra debug messages printed over serial. `state` should be `on` or `off` (no string quotes required).
+Turns on extra debug messages printed over serial. `state` should be `on` or `off` (no string quotes required). On by default.
 
 * `numtriggers`:  
 Responds with the number of triggers processed since the last call of `start`

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
 
   - Sweep and Single Stepping Mode (modes 4-6): `set <channel:int> <addr:int> <start_point:int> <end_point:int> <delta:int> <ramp-rate:int> <secondary1:int> <secondary2:int> (<time:int>)`
 
-    These modes perform a linear sweep on one of the parameters, while simulaneously single stepping on the other two parameters.
+    These modes perform a linear sweep on one of the parameters, while simultaneously single stepping on the other two parameters.
       - Amplitude Sweeps (mode 4)  
         `secondary1` is the frequency, and `secondary2` is the phase offset.
       - Frequency Sweeps (mode 5)  

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Finally, the program can be executed using the `start` or `hwstart` commands. If
 
 - The amplitude resolution of the AD9959 is $= \frac{1}{2^{10}} \approx 0.09767\%$. Amplitude scale factors given using the `set` command will be rounded to a multiple of this resolution. Amplitude scale factors given using the `seti` or `setb` commands will be in units of this resolution.
 
+- When the DDS Sweeper uses internal timing to execute instructions, that time is based on the number of clock cycles of the Pico's system clock (which defaults to 125 MHz for an 8 ns period). Timing inputs using the `set` command are given in seconds and will be rounded to an integer multiple of the Pico system clock period. Timing input using the `seti` or `setb` commands is defined to be in units of the Pico system clock period.
+
 ## Sweeps
 - Setting up a sweep:  
 ![Sweep Setup Figure](img/sweep-setup.png)  
@@ -169,8 +171,8 @@ Manually set the amplitude scale factor of a specified channel. Channels are 0-3
 
 * `set`:  
 Sets the value of instruction number `addr` for channel `channel` (zero indexed). `addr` starts at 0. It looks different depending on what mode the sweeper is in. If `Debug` is set to `on` it will respond with the actual values set for that instruction.
-  - Single Stepping (mode 0): `set <channel:int> <addr:int> <frequency:float> <amplitude:float> <phase:float> (<time:int>)`
-  - Sweep Mode (modes 1-3): `set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> (<time:int>)`
+  - Single Stepping (mode 0): `set <channel:int> <addr:int> <frequency:float> <amplitude:float> <phase:float> (<time:float>)`
+  - Sweep Mode (modes 1-3): `set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> (<time:float>)`
 
     `start_point` is the value the sweep should start from, and `end_point` is where it will stop. `delta` is the amount that the output should change by every cycle of the sweep clock. In the AD9959, the sweep clock runs at one quarter the system clock. The types of values expected for `start_point`, `end_point`, and `delta` different depending on the type of sweep  
       - Amplitude Sweeps (mode 1)  
@@ -180,7 +182,7 @@ Sets the value of instruction number `addr` for channel `channel` (zero indexed)
       - Phase Sweeps (mode 3)
         `start_point`, `end_point`, and `delta` are in degrees. They can have decimal values, but they will be rounded to the nearest multiple of the phase resolution (always $= 360^\circ / 2^{14} \approx 0.02197^\circ$). 
 
-  - Sweep and Single Stepping Mode (modes 4-6): `set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> <secondary1:double> <secondary2:double> (<time:int>)`
+  - Sweep and Single Stepping Mode (modes 4-6): `set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> <secondary1:double> <secondary2:double> (<time:float>)`
 
     These modes perform a linear sweep on one of the parameters, while simulaneously single stepping on the other two parameters.
       - Amplitude Sweeps (mode 4)  

--- a/dds-sweeper/ad9959.c
+++ b/dds-sweeper/ad9959.c
@@ -33,6 +33,13 @@ double get_pow(double phase, uint16_t* pow) {
     return *pow / 16383.0 * 360.0;
 }
 
+double get_time(ad9959_config* c, double time, uint32_t* periods) {
+    *periods = round(time / c->ref_clk);
+
+    // return time that was able to be set
+    return *periods * c->ref_clk
+}
+
 void load_acr(uint16_t asf, uint8_t* buf) {
     buf[0] = 0x00;
     buf[1] = ((0x0300 & asf) >> 8) | 0x10;

--- a/dds-sweeper/ad9959.c
+++ b/dds-sweeper/ad9959.c
@@ -34,10 +34,10 @@ double get_pow(double phase, uint16_t* pow) {
 }
 
 double get_time(ad9959_config* c, double time, uint32_t* cycles) {
-    *cycles = round(time / c->ref_clk);
+    *cycles = round(time * c->ref_clk);
 
     // return time that was able to be set
-    return *cycles * c->ref_clk;
+    return *cycles / c->ref_clk;
 }
 
 void load_acr(uint16_t asf, uint8_t* buf) {

--- a/dds-sweeper/ad9959.c
+++ b/dds-sweeper/ad9959.c
@@ -33,11 +33,11 @@ double get_pow(double phase, uint16_t* pow) {
     return *pow / 16383.0 * 360.0;
 }
 
-double get_time(ad9959_config* c, double time, uint32_t* periods) {
-    *periods = round(time / c->ref_clk);
+double get_time(ad9959_config* c, double time, uint32_t* cycles) {
+    *cycles = round(time / c->ref_clk);
 
     // return time that was able to be set
-    return *periods * c->ref_clk
+    return *cycles * c->ref_clk;
 }
 
 void load_acr(uint16_t asf, uint8_t* buf) {

--- a/dds-sweeper/ad9959.h
+++ b/dds-sweeper/ad9959.h
@@ -93,6 +93,7 @@ typedef struct ad9959_config {
 double get_asf(double amp, uint16_t* asf);
 double get_ftw(ad9959_config* c, double freq, uint32_t* ftw);
 double get_pow(double phase, uint16_t* pow);
+double get_time(ad9959_config* c, double time, uint32_t* cycles);
 
 void load_acr(uint16_t asf, uint8_t* buf);
 void load_ftw(uint32_t ftw, uint8_t* buf);

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -1095,7 +1095,6 @@ void loop() {
             } else {
                 set_ref_clk(&ad9959, freq);
                 gpio_deinit(PIN_CLOCK);
-                if (DEBUG) fast_serial_printf("AD9959 requires external reference clock\n");
             }
             // Set new mult if provided
             if (parsed == 3) {
@@ -1319,12 +1318,6 @@ void loop() {
                     if(ins_offset < 0) {
                         fast_serial_printf("Insufficient space for instruction\n");
                     } else {
-                        if (DEBUG) {
-                            fast_serial_printf(
-                                "Set ins #%d for channel %d with asf: %d "
-                                "ftw: %d pow: %d\n",
-                                addr, channel, asf, ftw, pow);
-                        }
 
                         set_single_step_ins(addr, channel, ftw, pow, asf);
                         if (timing) {

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -1185,7 +1185,7 @@ void loop() {
                             time = get_time(&ad9959, time, &cycles);
                             set_time(addr, cycles, ad9959.sweep_type, ad9959.channels);
                             if (DEBUG) {
-                                fast_serial_printf("\ttime: %9lf s\n", time);
+                                fast_serial_printf("\ttime: %.3g s\n", time);
                             }
                         }
                     }
@@ -1273,7 +1273,7 @@ void loop() {
                             time = get_time(&ad9959, time, &cycles);
                             set_time(addr, cycles, ad9959.sweep_type, ad9959.channels);
                             if (DEBUG) {
-                                fast_serial_printf("\ttime: %9lf s\n", time);
+                                fast_serial_printf("\ttime: %.3g s\n", time);
                             }
                         }
                     }

--- a/dds-sweeper/dds-sweeper.c
+++ b/dds-sweeper/dds-sweeper.c
@@ -334,7 +334,7 @@ void set_single_step_ins(uint addr, uint channel,
 
     // Memory Map (12 bytes)
     // [ 0x00, CSR                      *Channel Select Register
-    //   0x04, FTW3, FTW2, FTW1, FTW0,  *Frequcney Tuning Word
+    //   0x04, FTW3, FTW2, FTW1, FTW0,  *Frequency Tuning Word
     //   0x05, POW1, POW0,              *Phase Offset Word
     //   0x06, ACR2, ACR1, ACR0         *Amplitude Control Register
     // ]
@@ -871,7 +871,7 @@ void background() {
             // prime PIO
             pio_sm_put(PIO_TRIG, 0, instructions[offset]);
 
-            // send new instruciton to AD9959
+            // send new instruction to AD9959
             spi_write_blocking(SPI, instructions + offset + 1, step - 1);
 
             // if on the first instruction, begin the timer
@@ -1541,7 +1541,7 @@ int main() {
     // output sys clock on a gpio pin to be used as REF_CLK for AD9959
     clock_gpio_init(PIN_CLOCK, CLOCKS_CLK_GPOUT0_CTRL_AUXSRC_VALUE_CLK_SYS, 1);
 
-    // attatch spi to system clock so it runs at max rate
+    // attach spi to system clock so it runs at max rate
     clock_configure(clk_peri, 0, CLOCKS_CLK_PERI_CTRL_AUXSRC_VALUE_CLKSRC_PLL_SYS, 125 * MHZ,
                     125 * MHZ);
 


### PR DESCRIPTION
Fixes #54 

This PR also changes debug printing a bit by removing not overly necessary debug prints. They now only print rounding of input parameters for the set commands that accept floats.