### PR TITLE
Ensure errors in firmware build are properly caught in github action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         run: docker compose build --pull --build-arg APT_MIRROR="http://azure.archive.ubuntu.com/ubuntu/"
 
       - name: Run docker container
-        run: docker compose up
+        run: docker compose up --exit-code-from buildfirmware
 
       - name: Upload firmware as artifact
         uses: actions/upload-artifact@v4

--- a/dds-sweeper/ad9959.c
+++ b/dds-sweeper/ad9959.c
@@ -30,7 +30,7 @@ double get_pow(double phase, uint16_t* pow) {
     // make sure pow is within range?
     *pow = *pow % 16383;
 
-    return *pow / 16383.0 * 360.0;
+    return *pow / 16383.0 * 360.0
 }
 
 void load_acr(uint16_t asf, uint8_t* buf) {

--- a/dds-sweeper/ad9959.c
+++ b/dds-sweeper/ad9959.c
@@ -30,7 +30,7 @@ double get_pow(double phase, uint16_t* pow) {
     // make sure pow is within range?
     *pow = *pow % 16383;
 
-    return *pow / 16383.0 * 360.0
+    return *pow / 16383.0 * 360.0;
 }
 
 void load_acr(uint16_t asf, uint8_t* buf) {


### PR DESCRIPTION
Right now, firmware build failures aren't reported by the github action, and an artifact is still uploaded since the LICENSE file is always present.

This PR is testing fixes.