### PR TITLE
Dockerfile patch + typos and linting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,14 @@
 ## Overview of structure
 
 The DDS Sweeper can be divided into four components:
+
 1. A serial interface to the host computer running on the first core.
+
 2. An SPI interface to the AD9959 running on the second core.
-4. A PIO program for internal triggering (referred to as "timing") the DDS Sweeper.
-3. A PIO program for sending triggers to the AD9959.
+
+3. A PIO program for internal triggering (referred to as "timing") the DDS Sweeper.
+
+4. A PIO program for sending triggers to the AD9959.
 
 ## Serial interface
 
@@ -26,17 +30,17 @@ Both are stored in the same array, but timing information is offset to be after 
 
 The `instructions` array (when all four channels are enabled by `setchannels`) thus contains
 
-```
-    [profile pin for address 0] [channel 0 instruction at address 0] [channel 1 instruction at address 0] ... [channel 3 instruction at address 0]
-    [profile pin for address 1] [channel 0 instruction at address 1] [channel 1 instruction at address 1] ... [channel 3 instruction at address 1]
-    ...
-    [profile pin for last address] [channel 0 instruction at last address] [channel 1 instruction at last address] ... [channel 3 instruction at last address]
-	0x00 [0x00 for stop or 0xFF for repeat]
-	...
-	[time for instruction at address 0]
-	[time for instruction at address 1]
-	...
-	[time for instruction at last address]
+```text
+[profile pin for address 0] [channel 0 instruction at address 0] [channel 1 instruction at address 0] ... [channel 3 instruction at address 0]
+[profile pin for address 1] [channel 0 instruction at address 1] [channel 1 instruction at address 1] ... [channel 3 instruction at address 1]
+...
+[profile pin for last address] [channel 0 instruction at last address] [channel 1 instruction at last address] ... [channel 3 instruction at last address]
+0x00 [0x00 for stop or 0xFF for repeat]
+...
+[time for instruction at address 0]
+[time for instruction at address 1]
+...
+[time for instruction at last address]
 ```
 
 The profile pin byte is used in sweep modes to determine which profile pins to trigger (although SPI instructions will be sent for all channels, some of these could be empty, in which case nothing would happen to those channels). In single step mode, it is simply set to a non-zero value to indicate the the program does not stop or repeat yet.

--- a/SWEEP_DETAILS.md
+++ b/SWEEP_DETAILS.md
@@ -1,10 +1,10 @@
-## Sweeps
+# Sweeps
+
 - Setting up a sweep:  
 ![Sweep Setup Figure](img/sweep-setup.png)  
-Sweeps are defined by two parameters, sweep delta and ramp rate. 
+Sweeps are defined by two parameters, sweep delta and ramp rate.
 - Sweep Delta defines the change in output amplitude/frequency/phase on each sweep step
 - Ramp rate defines how often a sweep step is taken. It is based off of the AD9959's sync clock signal which will be one quarter of the AD9959's system clock. The ramp rate parameter specifies the number of sync clock cycles per sweep step. A ramp rate of 1 will cause the sweep delta to be applied every 1 sync clock cycle. For upward sweeps, the ramp rate parameter can have a value of 1-255. For downward sweeps the ramp rate can only be 1.  
-
 
 The time between sweep steps can be calculated with:
 $ t = \frac{\textrm{Ramp Rate}}{\textrm{Sync Clock}} $
@@ -13,20 +13,19 @@ For upward sweeps the time between sweeps can range from $\frac{1}{125 MHz} = 8 
 Downward sweeps will apply the sweep delta every $\frac{1}{125 MHz} = 8 ns$.  
 Given the frequency resolution of $\frac{f_{sys clk}}{2^{32}}$, the smallest sweep delta is $= \frac{1}{2^{32}} = 0.1164$ Hz. With the maximum ramp rates, the DDS-sweeper has a minimum sweeping rate of $\approx 47871$ Hz/sec when sweeping upwards or $\approx 12207031.25$ Hz/sec when sweeping downward.
 
+## Downward Sweeps
 
-### Downward Sweeps:
 Downward sweeps are not well supported by the AD9959, but they can still be done.
 The best method I have found for doing a downward sweep is to send the instructions via serial first, with the sweep autoclear bit set to active and the rising sweep tuning word set to the maximum.
 Then issue the IO_UPDATE signal while keeping the profile pin for that channel high.
-I belive this clears the sweep accumulator then quickly refills it with a max rate sweep before beginning the downward sweep. 
+I belive this clears the sweep accumulator then quickly refills it with a max rate sweep before beginning the downward sweep.
 Other combinations of autoclear bit active or not and timing of the profile pins seem to cause even more issues with downward sweeps.
 The biggest downside of this method is that you cannot slow down the downward sweep ramp rate as much as the upward sweep ramp rate.
 
-
 - Autoclear Accumulator Active, drop the pin after the update:  
-  Seems to work, you just cannot slow down downward sweeps. 
+  Seems to work, you just cannot slow down downward sweeps.
   ![Autoclear Accumulator Active, drop the pin after the update Closeup](img/profile-pin-drop-after.png)  
-  ![Autoclear Accumulator Active, drop the pin after the update Multiple Sweeps](img/noise-on-transition.png)   
+  ![Autoclear Accumulator Active, drop the pin after the update Multiple Sweeps](img/noise-on-transition.png)
 
 - Autoclear Accumulator Active, drop the pin before the update:  
   Downward sweeps just dont work at all.  
@@ -38,7 +37,7 @@ The biggest downside of this method is that you cannot slow down the downward sw
   ![no autoclear, drop pin before update: Closeup](img/no-auto-drop-before.png)  
   ![no autoclear, drop pin before update: Multiple Sweeps](img/consecutive-downs.png)  
 
-- no autoclear, drop pin after update:    
+- no autoclear, drop pin after update:
   A down sweep after an up sweep cannot cover a greater distance than the upward sweep  
   ![no autoclear, drop pin after update: Closeup](img/no-auto-drop-after.png)  
   ![no autoclear, drop pin after update: Multiple Sweeps](img/incomplete-sweep-after.png)  

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 
 # Install Pico SDK into a new stage
-FROM base as buildtools
+FROM base AS buildtools
 
 RUN \
     mkdir -p /pico/ && \

--- a/testing/binary-tests.ipynb
+++ b/testing/binary-tests.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +158,7 @@
     "        print(memory_layout)\n",
     "        # self.assert_OK, 'something went wrong getting memory layout'\n",
     "        \n",
-    "binary_routine_test = Binary_Routines()"
+    "binary_routine_test = BinaryRoutines()"
    ]
   },
   {
@@ -507,7 +507,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -524,7 +524,7 @@
     }
    ],
    "source": [
-    "phase_sweep_test = Binary_Routines()\n",
+    "phase_sweep_test = BinaryRoutines()\n",
     "phase_sweep_test.debug_off()\n",
     "phase_sweep_test.set_mode(sweep_mode=3, timing_mode=1, num_channels=2)\n",
     "\n",


### PR DESCRIPTION
Docker compose complains about the casing mismatch between "FROM" and "as" in our Dockerfile. Currently this doesn't actually block or stop anything, but they claim it will be a problem in the future. 

Also added are some linting fixes for our markdown files - I suspect there may be a merge conflict or two, or potentially a clash with the active PRs.