### PR TITLE
Fixing test notebook time scales

### DIFF
--- a/testing/tests.ipynb
+++ b/testing/tests.ipynb
@@ -264,8 +264,7 @@
   },
   {
    "cell_type": "code",
-
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -311,7 +310,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -336,7 +335,7 @@
        "27"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -380,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -430,7 +429,7 @@
        "'ok\\n'"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -464,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -473,7 +472,7 @@
        "'ok\\n'"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -507,13 +506,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-
     "### `clkstatus` and `setclk`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -530,9 +528,9 @@
       "\n",
       "pll_sys = 110000kHz\n",
       "pll_usb = 48000kHz\n",
-      "rosc = 5464kHz\n",
+      "rosc = 5458kHz\n",
       "clk_sys = 110000kHz\n",
-      "clk_peri = 110000kHz\n",
+      "clk_peri = 110001kHz\n",
       "clk_usb = 48000kHz\n",
       "clk_adc = 48000kHz\n",
       "clk_rtc = 47kHz\n",
@@ -551,7 +549,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -560,7 +558,7 @@
        "'ok\\n'"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -571,7 +569,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -584,8 +582,8 @@
       "\n",
       "pll_sys = 125000kHz\n",
       "pll_usb = 48000kHz\n",
-      "rosc = 5457kHz\n",
-      "clk_sys = 125001kHz\n",
+      "rosc = 5460kHz\n",
+      "clk_sys = 125000kHz\n",
       "clk_peri = 125000kHz\n",
       "clk_usb = 48000kHz\n",
       "clk_adc = 48000kHz\n",
@@ -621,7 +619,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -644,7 +642,7 @@
     "endPoint = 100 * MHZ\n",
     "totalTime = 2 # sec\n",
     "\n",
-    "spacing = 1000 * 10**(-6) # us\n",
+    "spacing = 10000 * 10**(-6) # us\n",
     "steps = round(totalTime / spacing)\n",
     "delta = (endPoint - startPoint) / steps\n",
     "\n",
@@ -653,7 +651,7 @@
     "send('setchannels 1')\n",
     "\n",
     "for i in range(steps):\n",
-    "    send(f'set 0 {i} {startPoint + delta * i} 1 0 {spacing * 10**9 / 8}', echo=False)\n",
+    "    send(f'set 0 {i} {startPoint + delta * i} 1 0 {spacing}', echo=False)\n",
     "assert send(f'set 4 {i + 1}') == \"ok\\n\"\n",
     "\n",
     "print(\"Table Programmed, Executing\")\n",
@@ -679,7 +677,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -710,7 +708,7 @@
     "send('setchannels 1')\n",
     "\n",
     "for i in range(steps):\n",
-    "    send(f'set 0 {i} {startFreq} {startPoint + delta * i} {startPhase} {spacing * 10**9 / 8}', echo=False)\n",
+    "    send(f'set 0 {i} {startFreq} {startPoint + delta * i} {startPhase} {spacing}', echo=False)\n",
     "\n",
     "assert send(f'set 4 {i + 1}') == \"ok\\n\"\n",
     "\n",
@@ -736,7 +734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -758,7 +756,7 @@
     "endPoint = 360\n",
     "totalTime = 2 # sec\n",
     "\n",
-    "spacing = 1000 * 10**(-6) # us\n",
+    "spacing = 10000 * 10**(-6) # us\n",
     "steps = round(totalTime / spacing)\n",
     "delta = (endPoint - startPoint) / steps\n",
     "\n",
@@ -767,7 +765,7 @@
     "send('setchannels 1')\n",
     "\n",
     "for i in range(steps):\n",
-    "    send(f'set 0 {i} {startFreq} {startAmp} {startPoint + delta * i} {spacing * 10**9 / 8}', echo=False)\n",
+    "    send(f'set 0 {i} {startFreq} {startAmp} {startPoint + delta * i} {spacing}', echo=False)\n",
     "\n",
     "assert send(f'set 4 {i + 1}') == \"ok\\n\"\n",
     "\n",
@@ -810,7 +808,7 @@
     "\n",
     "send('save')\n",
     "\n",
-    "# # destory current table\n",
+    "# # destroy current table\n",
     "time.sleep(2)\n",
     "for i in range(steps):\n",
     "    send(f'set 0 {i} 0 0 0 0', echo=False)\n",
@@ -840,8 +838,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```set <channel:int> <addr:int> <start_point:float> <end_point:float> <delta:float> (<time:float>)```"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -853,13 +858,14 @@
     }
    ],
    "source": [
-    "my_instrument.annotate_screen(\"Testing Mode 1\")\n",
-    "my_instrument.set_time_delay(35e-6)\n",
-    "my_instrument.set_time_scale(10e-6)\n",
+    "my_instrument.annotate_screen(\"Testing Mode 1: Amplitude Sweep\")\n",
+    "my_instrument.set_time_delay(50e-6)\n",
+    "my_instrument.set_time_scale(20e-6)\n",
     "\n",
     "# send('reset')\n",
     "\n",
     "filename = 'mode1-picostart-ampsweep-test.png'\n",
+    "t = 2000 / (125e6)\n",
     "\n",
     "send('debug off')\n",
     "send(f\"\"\"mode 1 1\n",
@@ -868,14 +874,22 @@
     "setfreq 1 100000000\n",
     "setfreq 2 100000000\n",
     "setfreq 3 100000000\n",
-    "set 0 0 1.0 0.0 0.001 1 2000\n",
-    "set 0 1 0.0 0.5 0.001 1 2000\n",
-    "set 0 2 0.5 1.0 0.001 1 2000\n",
-    "set 0 3 1.0 0.0 0.001 1 2000\n",
-    "set 0 4 0.0 1.0 0.001 1 2000\n",
-    "set 0 5 1.0 0.5 0.001 1 2000\n",
-    "set 0 6 0.5 0.0 0.001 1 2000\n",
-    "set 0 7 0.0 1.0 0.001 1 2000\n",
+    "set 0 0 1.0 0.0 0.001 {t}\n",
+    "set 0 1 0.0 0.5 0.001 {t}\n",
+    "set 0 2 0.5 1.0 0.001 {t}\n",
+    "set 0 3 1.0 0.0 0.001 {t}\n",
+    "set 0 4 0.0 1.0 0.001 {t}\n",
+    "set 0 5 1.0 0.5 0.001 {t}\n",
+    "set 0 6 0.5 0.0 0.001 {t}\n",
+    "set 0 7 0.0 1.0 0.001 {t}\n",
+    "set 0 0 1.0 0.0 0.001 {t}\n",
+    "set 0 1 0.0 0.5 0.001 {t}\n",
+    "set 0 2 0.5 1.0 0.001 {t}\n",
+    "set 0 3 1.0 0.0 0.001 {t}\n",
+    "set 0 4 0.0 1.0 0.001 {t}\n",
+    "set 0 5 1.0 0.5 0.001 {t}\n",
+    "set 0 6 0.5 0.0 0.001 {t}\n",
+    "set 0 7 0.0 1.0 0.001 {t}\n",
     "set 4 8\n",
     "start\n",
     "\"\"\")\n",
@@ -898,7 +912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -912,14 +926,14 @@
     "setfreq 1 100000000\n",
     "setfreq 2 100000000\n",
     "setfreq 3 100000000\n",
-    "set 0 0 1.0 0.0 0.001 1 2000\n",
-    "set 0 1 0.0 0.5 0.001 1 2000\n",
-    "set 0 2 0.5 1.0 0.001 1 2000\n",
-    "set 0 3 1.0 0.0 0.001 1 2000\n",
-    "set 0 4 0.0 1.0 0.001 1 2000\n",
-    "set 0 5 1.0 0.5 0.001 1 2000\n",
-    "set 0 6 0.5 0.0 0.001 1 2000\n",
-    "set 0 7 0.0 1.0 0.001 1 2000\n",
+    "set 0 0 1.0 0.0 0.001 2000\n",
+    "set 0 1 0.0 0.5 0.001 2000\n",
+    "set 0 2 0.5 1.0 0.001 2000\n",
+    "set 0 3 1.0 0.0 0.001 2000\n",
+    "set 0 4 0.0 1.0 0.001 2000\n",
+    "set 0 5 1.0 0.5 0.001 2000\n",
+    "set 0 6 0.5 0.0 0.001 2000\n",
+    "set 0 7 0.0 1.0 0.001 2000\n",
     "set 4 8\n",
     "hwstart\n",
     "\"\"\")\n",
@@ -959,7 +973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -973,9 +987,9 @@
    "source": [
     "my_instrument.annotate_screen(\"Testing Mode 2: Frequency Sweep\")\n",
     "my_instrument.set_time_delay(40e-6)\n",
-    "my_instrument.set_time_scale(10e-6)\n",
+    "my_instrument.set_time_scale(100e-6)\n",
     "\n",
-    "send('reset')\n",
+    "# send('reset')\n",
     "\n",
     "filename = 'mode2-freqsweep-test.png'\n",
     "\n",
@@ -988,22 +1002,22 @@
     "# f3 = 130e6\n",
     "\n",
     "d = 2000\n",
-    "t = 3000\n",
+    "t = 2000 / (125e6)\n",
     "\n",
     "send(\n",
     "f\"\"\"abort\n",
     "mode 2 1\n",
     "setchannels 1\n",
-    "set 0 0 {f1} {f3} {d * 1} 1 {t * 1}\n",
-    "set 0 1 {f3} {f2} {d / 4} 1 {t * 2}\n",
-    "set 0 2 {f2} {f1} {d * 1} 1 {t / 2}\n",
-    "set 0 3 {f1} {f1} {d * 0} 1 {t * 1}\n",
-    "set 0 4 {f2} {f2} {d * 0} 1 {t * 1}\n",
-    "set 0 5 {f3} {f3} {d * 0} 1 {t * 1}\n",
-    "set 0 6 {f3} {f1} {d * 0} 1 {t * 1}\n",
-    "set 0 7 {f1} {f2} {d / 4} 1 {t * 2}\n",
-    "set 0 8 {f2} {f3} {d * 0} 1 {t * 10}\n",
-    "set 0 9 {f1} {f1} {d * 0} 1 1\n",
+    "set 0 0 {f1} {f3} {d * 1} {t * 1}\n",
+    "set 0 1 {f3} {f2} {d / 4} {t * 2}\n",
+    "set 0 2 {f2} {f1} {d * 1} {t / 2}\n",
+    "set 0 3 {f1} {f1} {d * 0} {t * 1}\n",
+    "set 0 4 {f2} {f2} {d * 0} {t * 1}\n",
+    "set 0 5 {f3} {f3} {d * 0} {t * 1}\n",
+    "set 0 6 {f3} {f1} {d * 0} {t * 1}\n",
+    "set 0 7 {f1} {f2} {d / 4} {t * 2}\n",
+    "set 0 8 {f2} {f3} {d * 0} {t * 10}\n",
+    "set 0 9 {f1} {f1} {d * 0} 1\n",
     "set 4 10\n",
     "start\n",
     "\"\"\"\n",
@@ -1038,7 +1052,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -1047,7 +1061,7 @@
        "'ok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\nok\\n'"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1057,12 +1071,12 @@
     "f\"\"\"abort\n",
     "mode 2 0\n",
     "setchannels 1\n",
-    "set 0 0 {f1} {f3} {d} 1 {t}\n",
-    "set 0 1 {f3} {f2} {d} 1 {t}\n",
-    "set 0 2 {f2} {f1} {d} 1 {t}\n",
-    "set 0 3 {f1} {f2} {d} 1 {t}\n",
-    "set 0 4 {f2} {f3} {d} 1 {t}\n",
-    "set 0 5 {f3} {f1} {d} 1 {t}\n",
+    "set 0 0 {f1} {f3} {d} {t}\n",
+    "set 0 1 {f3} {f2} {d} {t}\n",
+    "set 0 2 {f2} {f1} {d} {t}\n",
+    "set 0 3 {f1} {f2} {d} {t}\n",
+    "set 0 4 {f2} {f3} {d} {t}\n",
+    "set 0 5 {f3} {f1} {d} {t}\n",
     "set 5 6\n",
     "hwstart\n",
     "\"\"\"\n",
@@ -1085,7 +1099,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
@@ -1099,8 +1113,8 @@
    "source": [
     "\n",
     "my_instrument.annotate_screen(\"Testing Mode 3: Phase Sweep\")\n",
-    "my_instrument.set_time_delay(35e-6)\n",
-    "my_instrument.set_time_scale(10e-6)\n",
+    "my_instrument.set_time_delay(40e-6)\n",
+    "my_instrument.set_time_scale(20e-6)\n",
     "\n",
     "my_instrument.set_math_offset(650e-3)\n",
     "my_instrument.set_math_scale(500e-3)\n",
@@ -1109,7 +1123,7 @@
     "\n",
     "filename = 'mode3-phasesweep-test.png'\n",
     "\n",
-    "t = 2000\n",
+    "t = 2000 / (125e6) # set time in seconds\n",
     "d = 0.2\n",
     "\n",
     "send(f\"\"\"abort\n",
@@ -1124,18 +1138,18 @@
     "setphase 3 0\n",
     "mode 3 1\n",
     "setchannels 2\n",
-    "set 0 0 0 0 0 0 {t}\n",
-    "set 0 1 0 0 0 0 {t}\n",
-    "set 0 2 0 0 0 0 {t}\n",
-    "set 0 3 0 0 0 0 {t}\n",
-    "set 0 4 0 0 0 0 {t}\n",
-    "set 0 5 0 0 0 0 {t}\n",
-    "set 1 0 0 180 {d} 1 {t}\n",
-    "set 1 1 180 90 {d} 1 {t}\n",
-    "set 1 2 90 0 {d} 1 {t}\n",
-    "set 1 3 0 90 {d} 1 {t}\n",
-    "set 1 4 90 180 {d} 1 {t}\n",
-    "set 1 5 180 0 {d} 1 {t}\n",
+    "set 0 0 0 0 0 {t}\n",
+    "set 0 1 0 0 0 {t}\n",
+    "set 0 2 0 0 0 {t}\n",
+    "set 0 3 0 0 0 {t}\n",
+    "set 0 4 0 0 0 {t}\n",
+    "set 0 5 0 0 0 {t}\n",
+    "set 1 0 0 180 {d} {t}\n",
+    "set 1 1 180 90 {d} {t}\n",
+    "set 1 2 90 0 {d} {t}\n",
+    "set 1 3 0 90 {d} {t}\n",
+    "set 1 4 90 180 {d} {t}\n",
+    "set 1 5 180 0 {d} {t}\n",
     "set 4 6\n",
     "start\n",
     "\"\"\")\n",
@@ -1160,19 +1174,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
     "send('reset')\n",
+    "my_instrument.set_time_delay(60e-6)\n",
+    "my_instrument.set_time_scale(20e-6)\n",
+    "\n",
     "\n",
     "my_instrument.annotate_screen(\"Testing seti Mode 3: Phase Sweep\")\n",
-    "my_instrument.set_math_offset(1.6)\n",
+    "my_instrument.set_math_offset(1.3)\n",
     "my_instrument.set_math_scale(0.1)\n",
     "\n",
     "filename = 'mode3-seti-phasesweep-test.png'\n",
     "\n",
-    "t = 2\n",
+    "t = 3000 # seti time in cycles\n",
     "d = 1\n",
     "\n",
     "send(f\"\"\"abort\n",
@@ -1233,7 +1250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1243,7 +1260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
@@ -1264,7 +1281,7 @@
     "f0 = 120 * MHZ\n",
     "\n",
     "d = 0.001\n",
-    "t = 2000\n",
+    "t = 2000 / (125e6)\n",
     "\n",
     "filename = 'mode4-ampsweep2-test.png'\n",
     "\n",
@@ -1310,27 +1327,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'ok\\n'"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# send('reset')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1347,9 +1353,8 @@
     "p1 = get_pow(phase = 90)\n",
     "p2 = get_pow(phase = 270)\n",
     "\n",
-    "\n",
     "d = 1\n",
-    "t = 2\n",
+    "t = 2000 # seti in cycles\n",
     "\n",
     "filename = 'mode4-seti-ampsweep2-test.png'\n",
     "\n",
@@ -1395,7 +1400,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -1404,7 +1409,7 @@
        "'ok\\n'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1415,7 +1420,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
@@ -1438,7 +1443,7 @@
     "f3 = 130e6\n",
     "\n",
     "d = .001\n",
-    "t = 2000\n",
+    "t = 2000 / (125e6)\n",
     "\n",
     "filename = 'mode5-freqsweep2-test.png'\n",
     "\n",
@@ -1493,13 +1498,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
     "my_instrument.annotate_screen(\"Testing seti Mode 5: Frequency Sweep, Single Step Amp, Phase\")\n",
-    "my_instrument.set_time_delay(80e-6)\n",
-    "my_instrument.set_time_scale(20e-6)\n",
+    "# my_instrument.set_time_delay(80e-6)\n",
+    "# my_instrument.set_time_scale(20e-6)\n",
     "\n",
     "my_instrument.set_math_scale(1)\n",
     "my_instrument.set_math_offset(1.5)\n",
@@ -1509,7 +1514,7 @@
     "f3 = get_ftw(freq_out = 118 * MHZ, freq_sys = 125 * MHZ)\n",
     "\n",
     "d = 1\n",
-    "t = 2\n",
+    "t = 2000\n",
     "\n",
     "filename = 'mode5-seti-freqsweep2-test.png'\n",
     "\n",
@@ -1580,28 +1585,16 @@
   },
   {
    "cell_type": "code",
-
-   "execution_count": 32,
+   "execution_count": 69,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'ok\\n'"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# send('reset') ## this test seems to draw only after multiple runs??"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1617,7 +1610,7 @@
     "f118 = 118e6\n",
     "f125 = 125 * MHZ\n",
     "d = 0.1\n",
-    "t = 2000\n",
+    "t = 2000 / 125e6\n",
     "\n",
     "filename = 'mode6-phasesweep2-test.png'\n",
     "\n",
@@ -1701,7 +1694,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1749,7 +1742,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
Updating testing notebook to incorporate change from #66 

all times from the `set` command now in units of seconds and `seti` in units of clock cycles